### PR TITLE
Remove prefer-stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,5 @@
   "scripts": {
     "lint": "phpcs --standard=tests/phpcs/ruleset.xml code/ tests/php/"
   },
-  "min-stability": "dev",
-  "prefer-stable": true
+  "min-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "silverstripe/framework": "^4@dev"
   },
   "require-dev": {
-    "phpunit/PHPUnit": "~4.8"
+    "phpunit/PHPUnit": "~4.8",
+    "silverstripe/framework": "^4.0@dev"
   },
   "extra": {
     "branch-alias": {
@@ -38,6 +39,5 @@
   },
   "scripts": {
     "lint": "phpcs --standard=tests/phpcs/ruleset.xml code/ tests/php/"
-  },
-  "min-stability": "dev"
+  }
 }


### PR DESCRIPTION
It checks out outdated tags on framework in builds,
which work differently from a `composer create-project` (module is composer root).
At least prior to beta1, we want to test against latest versions of dependencies.

Related build failure: https://travis-ci.org/silverstripe/silverstripe-admin/jobs/211094670#L445