### PR TITLE
Fix missing permissions codes for ModelAdmins

### DIFF
--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -2186,7 +2186,8 @@ class LeftAndMain extends Controller implements PermissionProvider
             // Check if modeladmin has explicit required_permission_codes option.
             // If a modeladmin is namespaced you can apply this config to override
             // the default permission generation based on fully qualified class name.
-            $code = $this->getRequiredPermissions();
+            $code = $class::getRequiredPermissions();
+            
             if (!$code) {
                 continue;
             }


### PR DESCRIPTION
When creating a new ModelAdmin subclass in 4.0 there is not a matching permission checkbox in the CMS. This is because the root LeftAndMain::providePermissions() handles the creating of the codes and $this->getRequiredPermissions is only called on the root LeftAndMain rather than the target class.