### PR TITLE
Remove status indicators on the Tree dropdown items text.

### DIFF
--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -14516,6 +14516,10 @@ div.TreeDropdownField .treedropdownfield-panel .tree-holder>ul{
   margin-bottom:10px;
 }
 
+div.TreeDropdownField .treedropdownfield-panel .tree-holder span.badge{
+  display:none;
+}
+
 div.TreeDropdownField .treedropdownfield-panel ul{
   overflow-x:hidden;
   float:left;

--- a/client/src/styles/legacy/TreeDropdownField.scss
+++ b/client/src/styles/legacy/TreeDropdownField.scss
@@ -83,6 +83,10 @@ div.TreeDropdownField {
         overflow-y: auto;
         margin-bottom: 10px;
       }
+
+      span.badge {
+        display: none;
+      }
     }
 
 		ul {


### PR DESCRIPTION
https://github.com/silverstripe/silverstripe-framework/issues/5702

I'd say just remove the status indicators. Pointer for how to fix: Make a change to a page and only save it without publication, which should cause a "modified" status in the tree. Go to admin/pages/add and choose "under another page". The _tree.scss styles contain a tree-status-icon mixin which is responsible for this styling. That's not replicated in TreeDropdownField.scss