### PR TITLE
Fix file size calculation in UploadField UI, add test coverage.

### DIFF
--- a/client/dist/js/bundle.js
+++ b/client/dist/js/bundle.js
@@ -1445,10 +1445,9 @@ n(this,e)}return r(e,null,[{key:"get",value:function e(t){return window.ss.confi
 }},{key:"getCurrentSection",value:function e(){}}]),e}()
 t.default=a},function(e,t,n){(function(t){e.exports=t.DataFormat=n(194)}).call(t,function(){return this}())},function(e,t,n){"use strict"
 function r(e){return e&&e.__esModule?e:{default:e}}function a(e){return d.default.parse(e.replace(/^\?/,""))}function i(e){var t=null,n=""
-return e<1024?(t=e,n="bytes"):e<1048576?(t=Math.round(e/1024),n="KB"):e<10485760?(t=Math.round(e/1048576*10)/10,n="MB"):e<1073741824&&(t=Math.round(e/1048576),n="MB"),(t||0===t)&&n||(t=Math.round(e/1073741824*10)/10,
-n="GB"),isNaN(t)?u.default._t("File.NO_SIZE","N/A"):t+" "+n}function s(e){return/[.]/.exec(e)?e.replace(/^.+[.]/,""):""}Object.defineProperty(t,"__esModule",{value:!0}),t.decodeQuery=a,t.fileSize=i,t.getFileExtension=s
-
-
+return e<1024?(t=e,n="bytes"):e<10240?(t=Math.round(e/1024*10)/10,n="KB"):e<1048576?(t=Math.round(e/1024),n="KB"):e<10485760?(t=Math.round(e/1048576*10)/10,n="MB"):e<1073741824&&(t=Math.round(e/1048576),
+n="MB"),(t||0===t)&&n||(t=Math.round(e/1073741824*10)/10,n="GB"),isNaN(t)?u.default._t("File.NO_SIZE","N/A"):t+" "+n}function s(e){return/[.]/.exec(e)?e.replace(/^.+[.]/,""):""}Object.defineProperty(t,"__esModule",{
+value:!0}),t.decodeQuery=a,t.fileSize=i,t.getFileExtension=s
 var o=n(117),u=r(o),l=n(13),d=r(l)},function(e,t,n){(function(t){e.exports=t.ReducerRegister=n(196)}).call(t,function(){return this}())},function(e,t){"use strict"
 function n(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}Object.defineProperty(t,"__esModule",{value:!0})
 var r=function(){function e(e,t){for(var n=0;n<t.length;n++){var r=t[n]

--- a/client/src/lib/DataFormat.js
+++ b/client/src/lib/DataFormat.js
@@ -22,6 +22,9 @@ export function fileSize(size) {
   if (size < 1024) {
     number = size;
     metric = 'bytes';
+  } else if (size < 1024 * 10) {
+    number = Math.round((size / 1024) * 10) / 10;
+    metric = 'KB';
   } else if (size < 1024 * 1024) {
     number = Math.round(size / 1024);
     metric = 'KB';

--- a/client/src/lib/tests/DataFormat-test.js
+++ b/client/src/lib/tests/DataFormat-test.js
@@ -6,7 +6,7 @@ jest.unmock('../DataFormat');
 jest.unmock('qs');
 jest.unmock('merge');
 
-import { decodeQuery } from '../DataFormat';
+import { decodeQuery, fileSize } from '../DataFormat';
 
 
 describe('DataFormat', () => {
@@ -16,6 +16,24 @@ describe('DataFormat', () => {
     });
     it('should decode nested keys (PHP style)', () => {
       expect(decodeQuery('?foo[bar]=1')).toEqual({ foo: { bar: '1' } });
+    });
+  });
+
+  describe('fileSize', () => {
+    it('should display the size of a 200 byte file', () => {
+      expect(fileSize(200)).toEqual('200 bytes');
+    });
+    it('should display the rounded size of a 200 kilobyte file', () => {
+      expect(fileSize(200 * 1024)).toEqual('200 KB');
+    });
+    it('should display the rounded size of a 2.76 megabyte file', () => {
+      expect(fileSize(2.76 * 1024 * 1024)).toEqual('2.8 MB');
+    });
+    it('should display the rounded size of a 200 megabyte file', () => {
+      expect(fileSize(200 * 1024 * 1024)).toEqual('200 MB');
+    });
+    it('should display the rounded size of a 2.76 gigabyte file', () => {
+      expect(fileSize(2.76 * 1024 * 1024 * 1024)).toEqual('2.8 GB');
     });
   });
 });


### PR DESCRIPTION
This fixes [framework #6663](https://github.com/silverstripe/silverstripe-framework/issues/6663), where the filesize displayed on uploaded images was wrong in most cases. It also adds test coverage to ensure there are no future regressions.