### PR TITLE
Unhide close button in modal

### DIFF
--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -15156,19 +15156,22 @@ div.TreeDropdownField a.jstree-loading .jstree-pageicon{
 }
 
 .form-builder-modal__close-button{
-  top:.9231rem;
-  right:.9231rem;
-  position:absolute;
-  z-index:61;
-  margin-right:0;
-  margin-top:-2px;
+  position:relative;
+  z-index:2;
+  font-size:28px;
   height:32px;
+  opacity:.5;
+  margin-top:0;
 }
 
 .form-builder-modal__close-button span{
   overflow:hidden;
   display:block;
-  margin-top:-7px;
+  margin-top:-6px;
+}
+
+.form-builder-modal__close-button:hover{
+  opacity:.7;
 }
 
 .form__field-message-item{
@@ -16280,6 +16283,8 @@ input.checkbox,input.radio,input[type=checkbox],input[type=radio]{
 }
 
 .modal-header .close{
+  position:relative;
+  z-index:2;
   font-size:28px;
   height:32px;
   opacity:.5;

--- a/client/src/components/FormBuilderModal/FormBuilderModal.scss
+++ b/client/src/components/FormBuilderModal/FormBuilderModal.scss
@@ -1,15 +1,18 @@
 .form-builder-modal__close-button {
-  top: $spacer-sm;
-  right: $spacer-sm;
-  position: absolute;
-  z-index: 61;
-  margin-right: 0;
-  margin-top: -2px;
+  position: relative;
+  z-index: 2;
+  font-size: 28px;
   height: 32px;
+  opacity: .5;
+  margin-top: 0;
 
   span {
     overflow: hidden;
     display: block;
-    margin-top: -7px;
+    margin-top: -6px;
+  }
+
+  &:hover {
+    opacity: .7;
   }
 }

--- a/client/src/components/Modal/Modal.scss
+++ b/client/src/components/Modal/Modal.scss
@@ -21,6 +21,8 @@
 
   // Close icon
   .close {
+    position: relative;
+    z-index: 2;
     font-size: 28px;
     height: 32px;
     opacity: .5;


### PR DESCRIPTION
Fix close button no longer hidden when success message flowed over modal header

Please see https://github.com/silverstripe/silverstripe-campaign-admin/issues/13 for more details