### PR TITLE
API Consistent use of inst() naming across framework

### DIFF
--- a/code/CMSMenu.php
+++ b/code/CMSMenu.php
@@ -430,7 +430,7 @@ class CMSMenu extends Object implements IteratorAggregate, i18nEntityProvider
         $entities = array();
         foreach ($cmsClasses as $cmsClass) {
             $defaultTitle = LeftAndMain::menu_title($cmsClass, false);
-            $ownerModule = ClassLoader::instance()->getManifest()->getOwnerModule($cmsClass);
+            $ownerModule = ClassLoader::inst()->getManifest()->getOwnerModule($cmsClass);
             $entities["{$cmsClass}.MENUTITLE"] = [
                 'default' => $defaultTitle,
                 'module' => $ownerModule->getShortName()

--- a/tests/php/LeftAndMainTest.php
+++ b/tests/php/LeftAndMainTest.php
@@ -24,7 +24,7 @@ class LeftAndMainTest extends FunctionalTest
         //$this->autoFollowRedirection = false;
         $this->resetMenu();
         $this->backupCombined = Requirements::get_combined_files_enabled();
-        $base = ModuleLoader::instance()->getManifest()->getModule('silverstripe/admin');
+        $base = ModuleLoader::inst()->getManifest()->getModule('silverstripe/admin');
         $assetsDir = File::join_paths($base->getRelativePath(), 'tests/php/assets');
 
         LeftAndMain::config()


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-framework/issues/6851

## Blocker

* https://github.com/silverstripe/silverstripe-framework/pull/6934