### PR TITLE
Extended width of TinyMCE area, with max width align with other fields

### DIFF
--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -16233,7 +16233,7 @@ input.checkbox,input.radio,input[type=checkbox],input[type=radio]{
     -webkit-box-flex:0;
         -ms-flex:0 0 100%;
             flex:0 0 100%;
-    max-width:1155px;
+    max-width:calc(895px + 16.66667%);
   }
 
   .cms-edit-form:not(.AssetAdmin) .form__field-extra-label,.form--inline .form__field-extra-label,.ss-insert-link .form__fieldgroup .form__field-extra-label{

--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -16229,6 +16229,13 @@ input.checkbox,input.radio,input[type=checkbox],input[type=radio]{
             flex:0 0 83.33333%;
   }
 
+  .cms-edit-form:not(.AssetAdmin) .form-group.htmleditor .form__field-holder,.form--inline .form-group.htmleditor .form__field-holder,.ss-insert-link .form__fieldgroup .form-group.htmleditor .form__field-holder{
+    -webkit-box-flex:0;
+        -ms-flex:0 0 100%;
+            flex:0 0 100%;
+    max-width:1155px;
+  }
+
   .cms-edit-form:not(.AssetAdmin) .form__field-extra-label,.form--inline .form__field-extra-label,.ss-insert-link .form__fieldgroup .form__field-extra-label{
     -webkit-box-flex:0;
         -ms-flex:0 0 16.66667%;

--- a/client/src/components/Form/Form.scss
+++ b/client/src/components/Form/Form.scss
@@ -312,6 +312,14 @@ input.radio {
       @include make-col-span(10);
     }
 
+    // HTML editor to expand to maximise to the space
+    .form-group.htmleditor .form__field-holder {
+      @include make-col-span(12);
+
+      // Custom width which visually matches other stacked fields
+      max-width: 1155px;
+    }
+
     .form__field-extra-label {
       @include make-col-span(2);
       @include make-col-offset(0);

--- a/client/src/components/Form/Form.scss
+++ b/client/src/components/Form/Form.scss
@@ -313,11 +313,10 @@ input.radio {
     }
 
     // HTML editor to expand to maximise to the space
+    // Max-width to visually match other stacked fields + label
     .form-group.htmleditor .form__field-holder {
       @include make-col-span(12);
-
-      // Custom width which visually matches other stacked fields
-      max-width: 1155px;
+      max-width: calc(#{$input-max-width} + 16.66667%);
     }
 
     .form__field-extra-label {


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-cms/issues/1773#issuecomment-302377616

At extreamly large sizes I've added an max-width which should align all fields on the right.
<img width="162" alt="pasted_image_19_05_17__3_37_pm" src="https://cloud.githubusercontent.com/assets/555033/26232264/1d326144-3ca9-11e7-8425-f89ffd701939.png">
