### PR TITLE
Set user themes on TinyMCEConfig before overwriting with admin themes

### DIFF
--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -663,6 +663,10 @@ class LeftAndMain extends Controller implements PermissionProvider
         $dummy = null;
         $this->extend('init', $dummy);
 
+        // Load the editor with original user themes before overwriting
+        // them with admin themes
+        TinyMCEConfig::set_user_themes(SSViewer::get_themes());
+
         // Assign default cms theme and replace user-specified themes
         SSViewer::set_themes(LeftAndMain::config()->uninherited('admin_themes'));
 

--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -665,7 +665,10 @@ class LeftAndMain extends Controller implements PermissionProvider
 
         // Load the editor with original user themes before overwriting
         // them with admin themes
-        TinyMCEConfig::set_user_themes(SSViewer::get_themes());
+        $themes = HTMLEditorConfig::config()->get('user_themes');
+        if (empty($themes)) {
+            HTMLEditorConfig::config()->set('user_themes', SSViewer::get_themes());
+        }
 
         // Assign default cms theme and replace user-specified themes
         SSViewer::set_themes(LeftAndMain::config()->uninherited('admin_themes'));


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-cms/issues/1865

**Depends on** https://github.com/silverstripe/silverstripe-framework/pull/7099