### PR TITLE
FIX Only show user's first name in CMS header

### DIFF
--- a/templates/SilverStripe/Admin/Includes/LeftAndMain_MenuStatus.ss
+++ b/templates/SilverStripe/Admin/Includes/LeftAndMain_MenuStatus.ss
@@ -3,8 +3,8 @@
         <a href="{$AdminURL}myprofile" class="cms-login-status__profile-link">
             <i class="font-icon-torso"></i>
             <span>
-                <%t SilverStripe\Admin\LeftAndMain.Hello 'Hi' %>
-                <% if $FirstName && $Surname %>$FirstName $Surname<% else_if $FirstName %>$FirstName<% else %>$Email<% end_if %>
+                <%t SilverStripe\\Admin\\LeftAndMain.Hello 'Hi' %>
+                <% if $FirstName %>$FirstName<% else %>$Email<% end_if %>
             </span>
         </a>
 	<% end_with %>


### PR DESCRIPTION
Resolves #139

Ironically when testing, the default admin's first name is Default Admin so you initially see no difference.

We could possibly look at removing the right padding on `.cms-login-status__profile-link` to give an extra letter, but this will continue to be a problem for longer first names.