### PR TITLE
Fix linting warnings in sass

### DIFF
--- a/client/src/components/Form/Form.scss
+++ b/client/src/components/Form/Form.scss
@@ -148,7 +148,7 @@
 .form__field-holder input.readonly,
 .form__field-holder span.readonly,
 .readonly .form__field-holder > div {
-  @extend .form-control-static;
+  @extend .form-control-static; // sass-lint:disable-line no-extends
 }
 
 // Fix for IE inputs not holding line-height

--- a/client/src/components/Menu/Menu.scss
+++ b/client/src/components/Menu/Menu.scss
@@ -1,28 +1,29 @@
+// sass-lint:disable no-css-comments
 /**
  * Styles for the left hand side menu and header for the admin panels.
  *
  * Take into consideration CSS selector performance.
  *
- * @package framework
- * @subpackage admin
+ * @package admin
  */
+// sass-lint:enable no-css-comments
 
 .cms-menu {
   z-index: $zindex-menu;
   background: $color-theme-bg;
   // Add `!important` to ignore width set in `.cms-panel` entwine`
-  width: $cms-menu-width !important;
+  width: $cms-menu-width !important; // sass-lint:disable-line no-important
 
   @include media-breakpoint-down(sm) {
     position: absolute;
     top: 0;
     left: -100%;
-    width: calc(100% - 59px) !important;
+    width: calc(100% - 59px) !important; // sass-lint:disable-line no-important
     transition: left $transition-speed-fast ease-in;
 
     &--open {
       left: 0;
-      height: 100% !important;
+      height: 100% !important; // sass-lint:disable-line no-important
       box-shadow: 1px 0 10px rgba(0, 0, 0, 0.2);
     }
   }
@@ -34,12 +35,14 @@
   .cms-panel-content {
     box-shadow: inset #C1C7CC -1px 0 0;
     overflow-x: hidden;
-    height: calc(100% - #{$toolbar-total-height * 3}) !important; // account for logo, logout and south bar
+    // account for logo, logout and south bar
+    height: calc(100% - #{$toolbar-total-height * 3}) !important; // sass-lint:disable-line no-important
   }
 
   @include media-breakpoint-up(md) {
     &.collapsed {
-      width: $cms-menu-width-collapsed !important; // Using important because JavaScript is overriding this value
+      // Using important because JavaScript is overriding this value
+      width: $cms-menu-width-collapsed !important; // sass-lint:disable-line no-important
       cursor: auto;
       z-index: 1000;
 
@@ -193,10 +196,10 @@
     margin-top: 3px;
     right: 8px;
     z-index: 2;
-    -ms-transform: rotate(-45deg); /* IE 9 */
-    -webkit-transform: rotate(-45deg); /* Chrome, Safari, Opera */
+    -ms-transform: rotate(-45deg); // IE 9
+    -webkit-transform: rotate(-45deg); // Chrome, Safari, Opera
     transform: rotate(-45deg);
-    // display: none;  /* To be shown by javascript, see LeftAndMain.Panel.js */
+    // display: none;  // To be shown by javascript, see LeftAndMain.Panel.js
   }
 
   .opened .toggle-children-icon {
@@ -228,9 +231,10 @@
 }
 
 .cms-menu__header {
-  position: relative !important;
-  top: auto !important;
-  height: auto !important;		// Required for JLayout
+  position: relative !important; // sass-lint:disable-line no-important
+  top: auto !important; // sass-lint:disable-line no-important
+  // Required for JLayout
+  height: auto !important; // sass-lint:disable-line no-important
   padding: 0;
   line-height: 24px;
   background-color: $color-brand-bg;
@@ -458,7 +462,7 @@
 
         .toggle-children {
           .toggle-children-icon {
-            @extend .icon-sprites-32x32;
+            @extend .icon-sprites-32x32; // sass-lint:disable-line no-extends
             @include sprite($sprites-32x32-menu-arrow-down);
           }
         }
@@ -533,7 +537,7 @@
       }
     }
 
-    /* Style applied to the menu flyout only when the collapsed setting */
+    // Style applied to the menu flyout only when the collapsed setting
     .collapsed-flyout {
       left: 59px;
       margin-top: -52px;
@@ -591,24 +595,20 @@
         border: 1px solid #d2d5d8;
         box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
 
-        li {
-          &.clone {
-            a {
-              padding: 15px 0 15px 70px;
-              margin-left: -60px;
-              margin-right: 0;
-              box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+        li.clone a {
+          padding: 15px 0 15px 70px;
+          margin-left: -60px;
+          margin-right: 0;
+          box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
 
-              span.text {
-                margin-left: -10px;
-              }
-            }
+          span.text {
+            margin-left: -10px;
           }
+        }
 
-          a span.text {
-            display: block;
-            margin-left: 0;
-          }
+        li a span.text {
+          display: block;
+          margin-left: 0;
         }
       }
 
@@ -622,9 +622,7 @@
   }
 }
 
-/**
- * Mobile menu toggle
- */
+// Mobile menu toggle
 .cms-mobile-menu-toggle-wrapper {
   display: none;
   position: absolute;

--- a/client/src/components/PopoverField/PopoverField.scss
+++ b/client/src/components/PopoverField/PopoverField.scss
@@ -10,7 +10,8 @@
   }
 
   .arrow {
-    @extend .popover-arrow; // Temp uses Bootstrap 3 class name, until React Bootstrap has been updated to Bootstrap 4
+    // Temp uses Bootstrap 3 class name, until React Bootstrap has been updated to Bootstrap 4
+    @extend .popover-arrow;
   }
 }
 
@@ -18,7 +19,8 @@
 
   // Unable to use classes within the popover, so we use elements to style
   ul {
-    padding-left: 0 !important; // TODO remove important by removing nesting of lists
+    // TODO remove important by removing nesting of lists
+    padding-left: 0 !important;
     list-style-type: none;
     margin-left: -#{$popover-padding} + 1px; // minus border
     margin-right: -#{$popover-padding} + 1px;

--- a/client/src/components/Tooltip/Tooltip.scss
+++ b/client/src/components/Tooltip/Tooltip.scss
@@ -1,11 +1,13 @@
+// sass-lint:disable no-css-comments
 /**
  * Workaround for tooltip placement. React bootstrap add class `left`, `right`,
  * `top` and `bottom` instead of `tooltip-left`, `tooltip-right`, `tooltip-top`
  * and `tooltip-bottom`.
  */
+// sass-lint:enable no-css-comments
 @each $dir in left, right, top, bottom {
   .tooltip.#{$dir} {
-    @extend .tooltip-#{$dir};
+    @extend .tooltip-#{$dir}; // sass-lint:disable-line no-extends
   }
 }
 

--- a/client/src/styles/_fonts.scss
+++ b/client/src/styles/_fonts.scss
@@ -14,6 +14,7 @@
 
 [class^="font-icon-"]::before,
 [class*=" font-icon-"]::before {
+  // sass-lint:disable-block no-important
   font-family: "silverstripe" !important;
   font-style: normal !important;
   font-weight: normal !important;

--- a/client/src/styles/_layout.scss
+++ b/client/src/styles/_layout.scss
@@ -22,8 +22,8 @@ body {
 
 // TODO move out of layout
 @include media-breakpoint-down(md) {
-  .CMSPageEditController,
-  .CMSPageSettingsController {
+  .CMSPageEditController, // sass-lint:disable-line class-name-format
+  .CMSPageSettingsController { // sass-lint:disable-line class-name-format
     &.has-panel .cms-content-tools {
       display: none;
     }

--- a/client/src/styles/editor.scss
+++ b/client/src/styles/editor.scss
@@ -3,7 +3,7 @@ $state-danger-bg: #f2dede;
 $state-danger-border: darken($state-danger-bg, 5%);
 $text-color: #fff;
 
-body.mceContentBody a.ss-broken {
+body.mceContentBody a.ss-broken { // sass-lint:disable-line class-name-format
   background-color: $state-danger-bg;
   border: 1px $state-danger-border solid;
   color: $text-color;


### PR DESCRIPTION
I've added `disable-line` comments to lines of css which cannot be avoided or fixed them (such as the multi-line comments)

There were a couple of warnings which I've left as they have an explicit `TODO` around them and makes sense to keep as warnings