### PR TITLE
FIX Allow CMSMenuItem creation to be skipped for LeftAndMain implementations

### DIFF
--- a/code/CMSMenu.php
+++ b/code/CMSMenu.php
@@ -91,9 +91,10 @@ class CMSMenu implements IteratorAggregate, i18nEntityProvider
         $urlBase = AdminRootController::admin_url();
         $urlSegment   = Config::inst()->get($controllerClass, 'url_segment');
         $menuPriority = Config::inst()->get($controllerClass, 'menu_priority');
+        $ignoreFromMenu = Config::inst()->get($controllerClass, 'ignore_menuitem');
 
-        // Don't add menu items defined the old way
-        if (!$urlSegment) {
+        // Don't add menu items defined the old way, or for controllers that are set to be ignored
+        if (!$urlSegment || $ignoreFromMenu) {
             return null;
         }
 


### PR DESCRIPTION
This change allows a controller that extends LeftAndMain to set a `private static $ignore_menuitem = true` so `CMSMenu::get_menu_items` will ignore it.

Some context about the reason for this change

* In SS3 a sub class of LeftAndMain is allowed without a `$url_segment`
* In SS4 the `$url_segment` is required
* The presence of a `$url_segment` is what is currently used to determine whether to add the result of `CMSMenu::menuitem_for_controller` to the menu items stack (see `::get_menu_items`). This means that a LeftAndMain subclass from SS3 would previously not have been in this stack, whereas in SS4 is now is (example is `SubsiteXHRController` in the subsites module)
* If that subclass of LeftAndMain has a `canView` method which calls `CMSMenu::get_viewable_menu_items` (like that subsites controller does) then an infinite loop is created, since that method creates each controller and calls `canView` on it. [Example here](https://github.com/silverstripe/silverstripe-subsites/blob/1.3.3/code/SubsiteXHRController.php#L11-L22)

