### PR TITLE
Make composer installs on travis more efficient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: php
 
-sudo: false
+dist: trusty
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
 
 addons:
   apt:
@@ -11,8 +15,6 @@ env:
   global:
     - TRAVIS_NODE_VERSION="6"
     - COMPOSER_ROOT_VERSION=1.0.x-dev
-    - DISPLAY=":99"
-    - XVFBARGS=":99 -ac -screen 0 1024x768x16"
 
 matrix:
   fast_finish: true
@@ -23,7 +25,7 @@ matrix:
       env: DB=MYSQL PHPUNIT_TEST=1 PHPCS_TEST=1
     - php: 7.0
       env: DB=MYSQL PHPUNIT_TEST=1
-    - php: 7.1.2
+    - php: 7.1
       env: DB=MYSQL PHPUNIT_TEST=1 PDO=1
     - php: 5.6
       env: NPM_TEST=1
@@ -39,12 +41,11 @@ before_script:
 
 # Install composer
   - composer validate
-  - composer install --prefer-dist
-  - composer require symfony/config:^3.2 silverstripe/framework:4.0.x-dev silverstripe/assets:1.0.x-dev embed/embed:^3.0@stable silverstripe/config:1.0.x-dev silverstripe/versioned:1.0.x-dev --prefer-dist --no-update
-  - composer update
-  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --prefer-dist; fi
-  - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.0.x-dev --prefer-dist; fi
-  - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
+  - composer require symfony/config:^3.2 silverstripe/framework:4.0.x-dev silverstripe/assets:1.0.x-dev embed/embed:^3.0@stable silverstripe/config:1.0.x-dev silverstripe/versioned:1.0.x-dev --no-update
+  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --no-update; fi
+  - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.0.x-dev --no-update; fi
+  - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile; fi
+  - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 # Install NPM dependencies
   - if [[ $NPM_TEST ]]; then nvm install $TRAVIS_NODE_VERSION && npm install -g yarn && yarn install --network-concurrency 1 && yarn run build; fi
@@ -56,4 +57,3 @@ script:
   - if [[ $NPM_TEST ]]; then yarn run lint; fi
   - if [[ $NPM_TEST ]]; then yarn run test; fi
   - if [[ $PHPCS_TEST ]]; then composer run-script lint; fi
-  - if [[ $PHPCS_TEST ]]; then composer validate; fi


### PR DESCRIPTION
- Clean up composer installs so the installation of deps only happens once
- Switch to trusty dist
- enable caching
- only call `composer validate` once
- Test PHP 7.1