### PR TITLE
Expose as vendor module

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,9 +1,0 @@
-<FilesMatch "\.(php|php3|php4|php5|phtml|inc)$">
-	Deny from all
-</FilesMatch>
-<FilesMatch "(main|rpc|tiny_mce_gzip)\.php$">
-	Allow from all
-</FilesMatch>
-<FilesMatch "silverstripe_version$">
-	Deny from all
-</FilesMatch>

--- a/_config.php
+++ b/_config.php
@@ -6,6 +6,8 @@
 
 use SilverStripe\Admin\CMSMenu;
 use SilverStripe\Admin\CMSProfileController;
+use SilverStripe\Core\Manifest\ModuleLoader;
+use SilverStripe\Core\Manifest\ModuleManifest;
 use SilverStripe\Forms\HTMLEditor\TinyMCEConfig;
 
 // Default CMS HTMLEditorConfig
@@ -49,21 +51,16 @@ TinyMCEConfig::get('cms')->setOptions($tinyMCEOptions);
 
 // Avoid creating global variables
 call_user_func(function () {
-    if (strcasecmp(__DIR__, BASE_PATH) === 0) {
-        // Admin is root
-        $clientPath = 'client';
-    } else {
-        // Asset-admin is subdir
-        $clientPath = basename(__DIR__) . '/client';
-    }
+    $module = ModuleLoader::inst()->getManifest()->getModule('silverstripe/admin');
+
     // Re-enable media dialog
     TinyMCEConfig::get('cms')
         ->enablePlugins(array(
             'contextmenu' => null,
             'image' => null,
-            'sslink' => "{$clientPath}/dist/js/TinyMCE_sslink.js",
-            'sslinkexternal' => "{$clientPath}/dist/js/TinyMCE_sslink-external.js",
-            'sslinkemail' => "{$clientPath}/dist/js/TinyMCE_sslink-email.js",
+            'sslink' => $module->getResource('client/dist/js/TinyMCE_sslink.js')->getURL(),
+            'sslinkexternal' => $module->getResource('client/dist/js/TinyMCE_sslink-external.js')->getURL(),
+            'sslinkemail' => $module->getResource('client/dist/js/TinyMCE_sslink-email.js')->getURL()
         ))
         ->setOption('contextmenu', 'sslink inserttable | cell row column deletetable');
 });

--- a/code/ModelAdmin.php
+++ b/code/ModelAdmin.php
@@ -79,10 +79,9 @@ abstract class ModelAdmin extends LeftAndMain
     private static $menu_priority = -0.5;
 
     /**
-     * @todo ensure copied to client/dist folder and link from there
      * @var string
      */
-    private static $menu_icon = 'silverstripe-admin/client/src/sprites/menu-icons/16x16/db.png';
+    private static $menu_icon_class = 'font-icon-database';
 
     private static $allowed_actions = array(
         'ImportForm',

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "silverstripe/admin",
     "description": "SilverStripe admin interface",
-    "type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
     "homepage": "http://silverstripe.org",
     "license": "BSD-3-Clause",
     "keywords": [
@@ -20,7 +20,8 @@
     ],
     "require": {
         "silverstripe/framework": "^4@dev",
-        "silverstripe/versioned": "^1@dev"
+        "silverstripe/versioned": "^1@dev",
+        "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {
         "phpunit/PHPUnit": "~4.8"
@@ -30,7 +31,11 @@
             "1.x-dev": "1.0.x-dev",
             "dev-master": "2.x-dev"
         },
-        "installer-name": "silverstripe-admin"
+        "expose": [
+          "client/dist",
+          "client/lang",
+          "thirdparty"
+        ]
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/issues/7405
Merge after https://github.com/silverstripe/silverstripe-framework/pull/7395

Manually tested by opening and saving `admin/pages` (incl. regenerating tinymce_gzip files in live mode). 

Test (after merging the framework pull request):

```
composer config repositories.admin vcs https://github.com/open-sausages/silverstripe-admin.git
composer require "silverstripe/siteconfig:dev-pulls/1/vendorise-me-baby as 1.0.x-dev"
```