### PR TITLE
Allow breadcrumbs to define HTML support or not.

### DIFF
--- a/templates/SilverStripe/Admin/Includes/CMSBreadcrumbs.ss
+++ b/templates/SilverStripe/Admin/Includes/CMSBreadcrumbs.ss
@@ -2,9 +2,9 @@
 	<h2 id="page-title-heading">
 		<% loop $Breadcrumbs %>
 			<% if $Last %>
-				<span class="cms-panel-link crumb last">$Title.XML</span>
+				<span class="cms-panel-link crumb last">$Title</span>
 			<% else %>
-				<a class="cms-panel-link crumb" href="$Link">$Title.XML</a>
+				<a class="cms-panel-link crumb" href="$Link">$Title</a>
 				<span class="sep">/</span>
 			<% end_if %>
 		<% end_loop %>


### PR DESCRIPTION
Required to add support for custom breadcrumb designs such as https://projects.invisionapp.com/share/2MDS99OTZ#/screens/256544889. This allows the breadcrumb to specify either HTML or Varchar support.

See related PRs:

- [x] https://github.com/silverstripe/silverstripe-cms/pull/1985
- [x] https://github.com/silverstripe/silverstripe-framework/pull/7449