### PR TITLE
FIX Remove duplicate "field" class in FieldGroup holder template

### DIFF
--- a/themes/cms-forms/templates/SilverStripe/Forms/FieldGroup_holder.ss
+++ b/themes/cms-forms/templates/SilverStripe/Forms/FieldGroup_holder.ss
@@ -1,4 +1,4 @@
-<div id="$HolderID" class="form-group field<% if $extraClass %> $extraClass<% end_if %>">
+<div id="$HolderID" class="form-group<% if $extraClass %> $extraClass<% end_if %>">
     <% if $Title %>
     	<label for="$ID" id="title-$ID" class="form__field-label">$Title</label>
     <% end_if %>


### PR DESCRIPTION
It is added automatically by `CompositeField::extraClass` anyway.