### PR TITLE
BUG Fix issue where you need to add 'menu_icon_class = false' to a ModelAdmin that has a defined "menu_icon" or else it won't show.

### DIFF
--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -1057,7 +1057,10 @@ class LeftAndMain extends Controller implements PermissionProvider
                             $menuIconStyling .= $menuIcon;
                         }
 
-                        $iconClass = LeftAndMain::menu_icon_class_for_class($menuItem->controller);
+                        $iconClass = false;
+                        if (!$menuIcon) {
+                            $iconClass = LeftAndMain::menu_icon_class_for_class($menuItem->controller);
+                        }
                     } else {
                         $iconClass = $menuItem->iconClass;
                     }


### PR DESCRIPTION
BUG Fix issue where you need to add 'menu_icon_class = false' to a ModelAdmin that has a defined "menu_icon" or else it won't show.