### PR TITLE
Guard use of admin module while bootstrapping

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -52,17 +52,19 @@ TinyMCEConfig::get('cms')->setOptions($tinyMCEOptions);
 // Avoid creating global variables
 call_user_func(function () {
     $module = ModuleLoader::inst()->getManifest()->getModule('silverstripe/admin');
-
-    // Re-enable media dialog
-    TinyMCEConfig::get('cms')
-        ->enablePlugins([
-            'contextmenu' => null,
-            'image' => null,
-            'sslink' => $module->getResource('client/dist/js/TinyMCE_sslink.js'),
-            'sslinkexternal' => $module->getResource('client/dist/js/TinyMCE_sslink-external.js'),
-            'sslinkemail' => $module->getResource('client/dist/js/TinyMCE_sslink-email.js'),
-        ])
-        ->setOption('contextmenu', 'sslink inserttable | cell row column deletetable');
+    
+    if ($module) {
+        // Re-enable media dialog
+        TinyMCEConfig::get('cms')
+            ->enablePlugins([
+                'contextmenu' => null,
+                'image' => null,
+                'sslink' => $module->getResource('client/dist/js/TinyMCE_sslink.js'),
+                'sslinkexternal' => $module->getResource('client/dist/js/TinyMCE_sslink-external.js'),
+                'sslinkemail' => $module->getResource('client/dist/js/TinyMCE_sslink-email.js'),
+            ])
+            ->setOption('contextmenu', 'sslink inserttable | cell row column deletetable');
+    }
 });
 
 CMSMenu::remove_menu_class(CMSProfileController::class);


### PR DESCRIPTION
When bootstrapping on initial installation the admin module returns null for the admin module, so `$module->getResource()` throws an error preventing the manifest from building.