### PR TITLE
HTML typo in cms template

### DIFF
--- a/templates/SilverStripe/Admin/Includes/LeftAndMain_MenuLogo.ss
+++ b/templates/SilverStripe/Admin/Includes/LeftAndMain_MenuLogo.ss
@@ -1,6 +1,6 @@
 <div class="cms-sitename">
     <a href="$ApplicationLink" class="cms-sitename__link font-icon-silverstripe font-icon-large" target="_blank" title="$ApplicationName (Version - $CMSVersion)">
-        <sapn class="sr-only">$ApplicationName</span> <% if $CMSVersion %><abbr class="cms-sitename__version">$CMSVersion</abbr><% end_if %>
+        <span class="sr-only">$ApplicationName</span> <% if $CMSVersion %><abbr class="cms-sitename__version">$CMSVersion</abbr><% end_if %>
     </a>
     <a class="cms-sitename__title" href="$BaseHref" target="_blank"><% if $SiteConfig %>$SiteConfig.Title<% else %>$ApplicationName<% end_if %></a>
 </div>


### PR DESCRIPTION
The span tag that displays the application name and version contains a typo