### PR TITLE
Make webpack work nicely when bin-links are off

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "@silverstripe/webpack-config": "^0.5.0",
     "babel-jest": "^20.0.3",
     "copy-webpack-plugin": "^4.2.0",
-    "jest-cli": "^19.0.2"
+    "jest-cli": "^19.0.2",
+    "webpack": "^2"
   },
   "resolutions": {
     "eslint": "^4.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6000,7 +6000,7 @@ webpack-sources@^1.0.1:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^2.6.1:
+webpack@^2, webpack@^2.6.1:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-2.7.0.tgz#b2a1226804373ffd3d03ea9c6bd525067034f6b1"
   dependencies:


### PR DESCRIPTION
When running on a shared drive through a VM, I have to use `--no-bin-links` when running `yarn`; these changes help with that.

Also, webpack isn't a direct dependency of the package, even though we need it, so this declares it correctly.