### PR TITLE
Add editorconfig rule for composer.json to be allowed four spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,3 +26,6 @@ insert_final_newline = false
 [admin/thirdparty/**]
 trim_trailing_whitespace = false
 insert_final_newline = false
+
+[composer.json]
+indent_size = 4


### PR DESCRIPTION
Parent issue https://github.com/silverstripe/silverstripe-installer/issues/189