### PR TITLE
MINOR Clarify that closeLabel will make alerts dismissible, fix story book example

### DIFF
--- a/client/src/components/FormAlert/README.md
+++ b/client/src/components/FormAlert/README.md
@@ -3,8 +3,15 @@
 Generates a bootstrap alert box, with state closing handled optionally.
 
 ## Example
+
 ```js
 <FormAlert type="error" value="There was a problem" />
+```
+
+As a dismissible alert:
+
+```js
+<FormAlert type="success" value="Everything worked fine!" closeLabel="close" />
 ```
 
 ## Properties
@@ -18,6 +25,8 @@ Generates a bootstrap alert box, with state closing handled optionally.
    * info
  * `onClosed` (function): For manual handling of showing and hiding the message, used in conjunction with `visible`.
  * `visible` (boolean): Manual set whether the message is hidden or shown.
- * `closeLabel` (string): The label for the screen reader close button.
+ * `closeLabel` (string): The label for the screen reader close button. Providing a value for this will make the
+   alert "dismissible."
+
 
  _NOTE:_ For other properties, please refer to the [reactstrap Alert](https://reactstrap.github.io/components/alerts/) documentation.

--- a/client/src/components/FormAlert/tests/FormAlert-story.js
+++ b/client/src/components/FormAlert/tests/FormAlert-story.js
@@ -25,9 +25,16 @@ storiesOf('Admin/FormAlert', module)
     </div>
   ))
   .add('Dismissable', () => (
-    <FormAlert
-      type="success"
-      value="This is an alert that can be dismissed"
-      closeLabel="close"
-    />
+    <div>
+      <FormAlert
+        type="success"
+        value="This is an alert that can be dismissed"
+        closeLabel="close"
+      />
+      <FormAlert
+        type="danger"
+        value="This is an alert that can be dismissed"
+        closeLabel="close"
+      />
+    </div>
   ));


### PR DESCRIPTION
Fixes #506 (story book issue)

This PR clarifies that providing the closeLabel prop will make the alert dismissible.