### PR TITLE
Update recipe branching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_script:
 
 # Install composer
   - composer validate
-  - composer require silverstripe/recipe-core:1.2.x-dev silverstripe/versioned:1.2.x-dev --no-update
+  - composer require silverstripe/recipe-core:4.2.x-dev silverstripe/versioned:1.2.x-dev --no-update
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --no-update; fi
   - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.0.x-dev --no-update; fi
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile; fi


### PR DESCRIPTION
Parent issue: https://github.com/silverstripe/recipe-core/issues/24

From 4.2 onwards all recipes will use the same numbering as the core framework version.