### PR TITLE
NEW Pattern library now has FormAction examples

### DIFF
--- a/client/src/components/FormAction/README.md
+++ b/client/src/components/FormAction/README.md
@@ -10,12 +10,14 @@ Used for form actions. For example a submit button.
  * `type` (string): Used for the button's `type` attribute. Defaults to `button`
  * `bootstrapButtonStyle` (string): The style of button to be shown, adds a class `btn-{style}` to the button. Defaults to `secondary`. Recommended values are:
    * 'primary'
-   * 'primary-outline'
+   * 'outline-secondary'
    * 'secondary'
-   * 'secondary-outline'
+   * 'outline-secondary'
    * 'link'
    * 'danger'
  * `icon` (string): The icon to be used on the button, adds `font-icon-{icon}` class to the button. See available icons [here](../../../../fonts/incon-reference.html).
  * `loading` (boolean): If true, replaces the text/icon with a loading icon.
  * `disabled` (boolean): If true, gives the button a visually disabled state and disables click events.
  * `extraClass` (string): Add extra custom classes.
+
+See the pattern library for examples.

--- a/client/src/components/FormAction/tests/FormAction-story.js
+++ b/client/src/components/FormAction/tests/FormAction-story.js
@@ -1,0 +1,150 @@
+import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import FormAction from 'components/FormAction/FormAction';
+
+storiesOf('Admin/FormAction', module)
+  .add('States', () => (
+    <div>
+      <FormAction
+        title="Primary"
+        data={{ buttonStyle: 'primary' }}
+      />
+      <FormAction
+        title="Secondary"
+        data={{ buttonStyle: 'secondary' }}
+      />
+      <FormAction
+        title="Danger"
+        data={{ buttonStyle: 'danger' }}
+      />
+      <FormAction
+        title="Warning"
+        data={{ buttonStyle: 'warning' }}
+      />
+      <FormAction
+        title="Info"
+        data={{ buttonStyle: 'info' }}
+      />
+      <FormAction
+        title="Link"
+        data={{ buttonStyle: 'link' }}
+      />
+    </div>
+  ))
+  .add('Outline', () => (
+    <div>
+      <FormAction
+        title="Primary"
+        data={{ buttonStyle: 'outline-primary' }}
+      />
+      <FormAction
+        title="Secondary"
+        data={{ buttonStyle: 'outline-secondary' }}
+      />
+      <FormAction
+        title="Danger"
+        data={{ buttonStyle: 'outline-danger' }}
+      />
+      <FormAction
+        title="Warning"
+        data={{ buttonStyle: 'outline-warning' }}
+      />
+      <FormAction
+        title="Info"
+        data={{ buttonStyle: 'outline-info' }}
+      />
+    </div>
+  ))
+  .add('Icons', () => (
+    <div>
+      <FormAction
+        title="Rocket"
+        icon="rocket"
+        data={{ buttonStyle: 'primary' }}
+      />
+      <FormAction
+        title="Upload"
+        icon="save"
+        data={{ buttonStyle: 'secondary' }}
+      />
+    </div>
+  ))
+  .add('Loading', () => (
+    <div>
+      <FormAction
+        title="Loading"
+        loading
+        data={{ buttonStyle: 'primary' }}
+      />
+      <FormAction
+        title="Loading"
+        loading
+        data={{ buttonStyle: 'secondary' }}
+      />
+    </div>
+  ))
+  .add('Disabled', () => (
+    <div>
+      <p>
+        <FormAction
+          title="Primary"
+          disabled
+          data={{ buttonStyle: 'primary' }}
+        />
+        <FormAction
+          title="Secondary"
+          disabled
+          data={{ buttonStyle: 'secondary' }}
+        />
+        <FormAction
+          title="Danger"
+          disabled
+          data={{ buttonStyle: 'danger' }}
+        />
+        <FormAction
+          title="Warning"
+          disabled
+          data={{ buttonStyle: 'warning' }}
+        />
+        <FormAction
+          title="Info"
+          disabled
+          data={{ buttonStyle: 'info' }}
+        />
+        <FormAction
+          title="Link"
+          disabled
+          data={{ buttonStyle: 'link' }}
+        />
+      </p>
+
+      <p>
+        <FormAction
+          title="Primary"
+          disabled
+          data={{ buttonStyle: 'outline-primary' }}
+        />
+        <FormAction
+          title="Secondary"
+          disabled
+          data={{ buttonStyle: 'outline-secondary' }}
+        />
+        <FormAction
+          title="Danger"
+          disabled
+          data={{ buttonStyle: 'outline-danger' }}
+        />
+        <FormAction
+          title="Warning"
+          disabled
+          data={{ buttonStyle: 'outline-warning' }}
+        />
+        <FormAction
+          title="Info"
+          disabled
+          data={{ buttonStyle: 'outline-info' }}
+        />
+      </p>
+    </div>
+  ));


### PR DESCRIPTION
We had a case in campaign-admin where the wrong outline classes were used, so I've added some quick examples to the pattern library.

![image](https://user-images.githubusercontent.com/5170590/42139989-31357e3a-7dec-11e8-8c63-4adc72c8aa98.png)
![image](https://user-images.githubusercontent.com/5170590/42139990-37139bfc-7dec-11e8-8615-72d8ec10767a.png)
![image](https://user-images.githubusercontent.com/5170590/42139994-3b721822-7dec-11e8-902b-eecef2b2b3a7.png)
![image](https://user-images.githubusercontent.com/5170590/42139996-422c53ee-7dec-11e8-8041-76089195f92e.png)
![image](https://user-images.githubusercontent.com/5170590/42139998-4657c14c-7dec-11e8-9e37-85ff8245014b.png)
