### PR TITLE
Fix test for password recovery

### DIFF
--- a/tests/behat/features/lostpassword.feature
+++ b/tests/behat/features/lostpassword.feature
@@ -12,7 +12,7 @@ Feature: Lost Password
     When I follow "I've lost my password"
     And I fill in "admin@example.org" for "Email"
     And I press the "Send me the password reset link" button
-    Then I should see "A reset link has been sent to 'admin@example.org'"
+    Then I should see "A reset link has been sent"
     And there should be an email to "admin@example.org" titled "Your password reset link"
     When I click on the "password reset link" link in the email to "admin@example.org"
     Then I should see "Please enter a new password"


### PR DESCRIPTION
This test shouldn't be in admin, since the feature is placed in framework.
See https://github.com/silverstripe/silverstripe-framework/issues/8080
Relies on https://github.com/silverstripe/silverstripe-framework/pull/8223