### PR TITLE
Don't include font source in export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,7 +14,6 @@
 /client/src/bundles export-ignore
 /client/src/components export-ignore
 /client/src/containers export-ignore
-/client/src/font export-ignore
 /client/src/images export-ignore
 /client/src/legacy export-ignore
 /client/src/lib export-ignore


### PR DESCRIPTION
The font directory includes `icons-reference.html`, which is _really_ useful for picking icons.