### PR TITLE
Fix Add mock store to the loadComponent ApolloProvider

### DIFF
--- a/client/src/lib/dependency-injection/tests/loadComponent-test.js
+++ b/client/src/lib/dependency-injection/tests/loadComponent-test.js
@@ -3,6 +3,9 @@
 
 import React from 'react';
 import ReactTestUtils from 'react-addons-test-utils';
+import { createStore } from 'redux';
+
+const mockStore = createStore(state => state);
 
 function TestComponent() {
   return <span>abc</span>;
@@ -75,7 +78,7 @@ describe('loadComponent', () => {
   });
 
   it('should return a rendered ApolloProvider if it has mounted', () => {
-    const Temp = loadComponent(TestComponent, {}, mockProvider);
+    const Temp = loadComponent(TestComponent, { store: mockStore }, mockProvider);
     const temp = ReactTestUtils.renderIntoDocument(<Temp />);
     const rendered = temp.render();
 


### PR DESCRIPTION
Fixing #524 .

I've added a MockStore to the loadComponent ApolloProvider provider test to suppress the warning that Apollo requires a redux store.