### PR TITLE
FIX Quote injector alias references, deprecated and removed support for in Symfony 4

### DIFF
--- a/_config/injector.yml
+++ b/_config/injector.yml
@@ -9,4 +9,4 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\GraphQL\Controller.admin:
     class: SilverStripe\GraphQL\Controller
     constructor:
-      manager: %$SilverStripe\GraphQL\Manager.admin
+      manager: '%$SilverStripe\GraphQL\Manager.admin'

--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -6,7 +6,7 @@ Only:
 SilverStripe\Control\Director:
   rules:
     'admin/graphql':
-      Controller: %$SilverStripe\GraphQL\Controller.admin
+      Controller: '%$SilverStripe\GraphQL\Controller.admin'
       Stage: Stage
       Permissions:
         CMS_ACCESS: CMS_ACCESS


### PR DESCRIPTION
```
PHP Deprecated: Not quoting the scalar "%$SilverStripe\GraphQL\Manager.admin" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 on line 9. in /Users/robbieaverill/dev/ss43/vendor/symfony/yaml/Inline.php on line 357
PHP Deprecated: Not quoting the scalar "%$SilverStripe\GraphQL\Controller.admin" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 on line 4. in /Users/robbieaverill/dev/ss43/vendor/symfony/yaml/Inline.php on line 357
PHP Deprecated: Not quoting the scalar "%$SilverStripe\GraphQL\Manager.default" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 on line 14. in /Users/robbieaverill/dev/ss43/vendor/symfony/yaml/Inline.php on line 357
```