### PR TITLE
FIX Readding ARCHIVECONFIRMMESSAGE

### DIFF
--- a/client/lang/src/en.json
+++ b/client/lang/src/en.json
@@ -17,6 +17,7 @@
     "Admin.ANY": "Any",
     "Admin.ERRORINTRANSACTION": "An error occured while fetching data from the server\n Please try again later.",
     "Admin.DELETECONFIRMMESSAGE": "Are you sure you want to delete this record?",
+    "Admin.ARCHIVECONFIRMMESSAGE": "Are you sure you want to archive this record?",
     "Admin.EXPANDPANEL": "Expand panel",
     "Admin.COLLAPSEPANEL": "Collapse panel",
     "Admin.VALIDATOR_MESSAGE_REQUIRED": "{name} is required.",


### PR DESCRIPTION
The translation key for the archive confirmation message is missing from admin.

# Parent issue
* #753