### PR TITLE
Fix behat reauthenticate tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ before_script:
 
 # Install composer
   - composer validate
-  - composer require silverstripe/recipe-testing:^1 silverstripe/recipe-core:4.3.x-dev silverstripe/versioned:1.3.x-dev --no-update
+  - composer require silverstripe/recipe-testing:1.x-dev silverstripe/recipe-core:4.3.x-dev silverstripe/versioned:1.3.x-dev --no-update
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.1.x-dev --no-update; fi
   - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.0.x-dev --no-update; fi
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ addons:
 
 env:
   global:
-    - TRAVIS_NODE_VERSION="6"
     - COMPOSER_ROOT_VERSION=1.3.x-dev
     - DISPLAY=":99"
     - XVFBARGS=":99 -ac -screen 0 1024x768x16"
@@ -73,7 +72,7 @@ before_script:
   - composer show
 
 # Install NPM dependencies
-  - if [[ $NPM_TEST ]]; then nvm install $TRAVIS_NODE_VERSION && npm install -g yarn && yarn install --network-concurrency 1; fi
+  - if [[ $NPM_TEST ]]; then nvm install && npm install -g yarn && yarn install --network-concurrency 1; fi
 
 # Start behat services
   - if [[ $BEHAT_TEST ]]; then mkdir artifacts; fi

--- a/tests/behat/features/reauthenticate.feature
+++ b/tests/behat/features/reauthenticate.feature
@@ -14,19 +14,18 @@ Feature: Reauthenticate
   Scenario: Reauthenticate with correct login
     When I press the "Add Member" button
       And I switch to the "login-dialog-iframe" iframe
-    Then I should see "You must be logged in" in the ".cms-security__container" element
+    Then I should see "Your session has timed out due to inactivity" in the ".cms-security__container" element
     When I fill in "Password" with "Secret!123"
       And I press the "Let me back in" button
       And I am not in an iframe
       And I go to "/admin/security"
     When I press the "Add Member" button
-      And I wait for 5 seconds until I see the "#Form_ItemEditForm_action_doSave" element
     Then I should see "Create" in the "#Form_ItemEditForm_action_doSave" element
 
   Scenario: Reauthenticate with wrong login
     When I press the "Add Member" button
       And I switch to the "login-dialog-iframe" iframe
-    Then I should see "You must be logged in" in the ".cms-security__container" element
+    Then I should see "Your session has timed out due to inactivity" in the ".cms-security__container" element
     When I fill in "Password" with "wrong password"
       And I press the "Let me back in" button
     Then I should see "The provided details don't seem to be correct. Please try again."
@@ -35,5 +34,4 @@ Feature: Reauthenticate
       And I am not in an iframe
       And I go to "/admin/security"
     When I press the "Add Member" button
-      And I wait for 5 seconds until I see the "#Form_ItemEditForm_action_doSave" element
     Then I should see "Create" in the "#Form_ItemEditForm_action_doSave" element


### PR DESCRIPTION
Fix wording and remove explicit await for the server response;
From now onward we rely on the testsession:2.2 feature
allowing us to wait transparently for server to respond
after each step.

Requires:
 - [x] https://github.com/silverstripe/silverstripe-behat-extension/pull/185
 - [x] https://github.com/silverstripe/silverstripe-testsession/pull/58