### PR TITLE
MINOR FIX Patternlib to work on IE11

### DIFF
--- a/client/src/font/tests/Icons-story.js
+++ b/client/src/font/tests/Icons-story.js
@@ -9,7 +9,7 @@ const shadow = document.createElement('html');
 shadow.innerHTML = content;
 
 const mapping = shadow.querySelector('.css-mapping');
-mapping.querySelectorAll('input').forEach((input) => input.classList.add('form-control'));
+Array.prototype.slice.call(mapping.querySelectorAll('input')).forEach((input) => input.classList.add('form-control'));
 
 const styles = `
   /* styles that help style the borrowed HTML */


### PR DESCRIPTION
The pattern lib wasn't working on IE 11 because the Icon story tries to call `forEach` on a nodelist which is not available in IE11.

# Parent issue
* https://github.com/silverstripe/silverstripe-admin/issues/794