### PR TITLE
NEW: Add getter for ModelAdmin::$modelClass

### DIFF
--- a/code/ModelAdmin.php
+++ b/code/ModelAdmin.php
@@ -320,7 +320,6 @@ abstract class ModelAdmin extends LeftAndMain
         return $form;
     }
 
-
     /**
      * You can override how ModelAdmin returns DataObjects by either overloading this method, or defining an extension
      * to ModelAdmin that implements the `updateList` method (and takes a {@link \SilverStripe\ORM\DataList} as the
@@ -347,6 +346,16 @@ abstract class ModelAdmin extends LeftAndMain
         return $list;
     }
 
+    /**
+     * The model managed by this instance.
+     * See $managed_models for potential values.
+     *
+     * @return string
+     */
+    public function getModelClass()
+    {
+        return $this->modelClass;
+    }
 
     /**
      * @return \SilverStripe\ORM\ArrayList An ArrayList of all managed models to build the tabs for this ModelAdmin


### PR DESCRIPTION
Solves: https://github.com/silverstripe/silverstripe-admin/issues/812

As per @ScopeyNZ comment in the above issue, this wouldn't be part of a release until 1.4, so I've assumed that master is the correct branch, but correct me if I'm wrong.

Ideally this could go out in a patch release on 1.3 so that `silverstripe-multisites` can be made compatible with SS 4.3, but perhaps 4.4 isn't far off?

Cheers.