### PR TITLE
FIX TinyMCE editor.scss now applies to the correct body class, and has correct broken link colours

### DIFF
--- a/client/dist/styles/editor.css
+++ b/client/dist/styles/editor.css
@@ -1,1 +1,1 @@
-body.mceContentBody a.ss-broken{background-color:#f2dede;border:1px solid #ebcccc;color:#fff;padding:1px;text-decoration:underline}
+body.mce-content-body a.ss-broken{background-color:#d40404;border:1px solid #bb0404;color:#fff;padding:1px;text-decoration:underline}

--- a/client/src/styles/editor.scss
+++ b/client/src/styles/editor.scss
@@ -1,9 +1,9 @@
 // Editor variables
-$state-danger-bg: #f2dede;
+$state-danger-bg: #d40404;
 $state-danger-border: darken($state-danger-bg, 5%);
 $text-color: #fff;
 
-body.mceContentBody a.ss-broken { // sass-lint:disable-line class-name-format
+body.mce-content-body a.ss-broken {
   background-color: $state-danger-bg;
   border: 1px $state-danger-border solid;
   color: $text-color;


### PR DESCRIPTION
Fixes #850 and fixes https://github.com/silverstripe/silverstripe-externallinks/issues/49

![image](https://user-images.githubusercontent.com/5170590/54796593-ad316d80-4cb5-11e9-8929-011b63fee86b.png)
