### PR TITLE
FIX Add offending class to exception message

### DIFF
--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -865,7 +865,9 @@ class LeftAndMain extends Controller implements PermissionProvider
             // Get url_segment
             $segment = $this->config()->get('url_segment');
             if (!$segment) {
-                throw new BadMethodCallException("LeftAndMain subclasses must have url_segment");
+                throw new BadMethodCallException(
+                    sprintf('LeftAndMain subclasses (%s) must have url_segment', static::class)
+                );
             }
         }
 


### PR DESCRIPTION
Simple wording update to save time when reviewing this exception - show the class that's probably missing the configuration.