### PR TITLE
BUG Remove buggy code from LeftAndMain Breadcrumb

### DIFF
--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -1186,26 +1186,6 @@ class LeftAndMain extends Controller implements PermissionProvider
                 'Link' => ($unlinked) ? false : $this->Link()
             ))
         ));
-        $record = $this->currentPage();
-        if ($record && $record->exists()) {
-            if ($record->hasExtension(Hierarchy::class)) {
-                /** @var DataObject|Hierarchy $record */
-                $ancestors = $record->getAncestors();
-                $ancestors = new ArrayList(array_reverse($ancestors->toArray()));
-                $ancestors->push($record);
-                foreach ($ancestors as $ancestor) {
-                    $items->push(new ArrayData(array(
-                        'Title' => ($ancestor->MenuTitle) ? $ancestor->MenuTitle : $ancestor->Title,
-                        'Link' => ($unlinked) ? false : Controller::join_links($this->Link('show'), $ancestor->ID)
-                    )));
-                }
-            } else {
-                $items->push(new ArrayData(array(
-                    'Title' => ($record->MenuTitle) ? $record->MenuTitle : $record->Title,
-                    'Link' => ($unlinked) ? false : Controller::join_links($this->Link('show'), $record->ID)
-                )));
-            }
-        }
 
         return $items;
     }


### PR DESCRIPTION
Not sure exactly what this piece of code is trying to do, but it's doing it very poorly.

`SecurityAdmin` is the only controller I could find actually relying on it. All the other `LeftAndMain` child class overrides that method any way.

Removing it doesn't seem to lead to obviously bad results. It's not clear to me that there's obvious value in displaying a hierarchy in the breadcrumb even for groups.

# Parent issue
* #742