### PR TITLE
API Convert SecurityAdmin to be a ModelAdmin

### DIFF
--- a/code/SecurityAdmin.php
+++ b/code/SecurityAdmin.php
@@ -29,39 +29,29 @@ use SilverStripe\View\Requirements;
 /**
  * Security section of the CMS
  */
-class SecurityAdmin extends LeftAndMain implements PermissionProvider
+class SecurityAdmin extends ModelAdmin implements PermissionProvider
 {
+
+    private static $managed_models = [
+        Member::class,
+        Group::class,
+        PermissionRole::class
+    ];
 
     private static $url_segment = 'security';
 
-    private static $url_rule = '/$Action/$ID/$OtherID';
-
     private static $menu_title = 'Security';
-
-    private static $tree_class = Group::class;
-
-    private static $subitem_class = Member::class;
 
     private static $required_permission_codes = 'CMS_ACCESS_SecurityAdmin';
 
     private static $menu_icon_class = 'font-icon-torsos-all';
-
-    private static $allowed_actions = array(
-        'EditForm',
-        'MemberImportForm',
-        'memberimport',
-        'GroupImportForm',
-        'groupimport',
-        'groups',
-        'users',
-        'roles'
-    );
 
     /**
      * Shortcut action for setting the correct active tab.
      *
      * @param HTTPRequest $request
      * @return HTTPResponse
+     * @deprecated 1.5
      */
     public function users($request)
     {
@@ -73,6 +63,7 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider
      *
      * @param HTTPRequest $request
      * @return HTTPResponse
+     * @deprecated 1.5
      */
     public function groups($request)
     {
@@ -84,231 +75,11 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider
      *
      * @param HTTPRequest $request
      * @return HTTPResponse
+     * @deprecated 1.5
      */
     public function roles($request)
     {
         return $this->index($request);
-    }
-
-    public function getEditForm($id = null, $fields = null)
-    {
-        // Build gridfield configs
-        $memberListConfig = GridFieldConfig_RecordEditor::create()
-            ->addComponent(new GridFieldExportButton('buttons-before-left'));
-        $groupListConfig = GridFieldConfig_RecordEditor::create()
-            ->addComponent(new GridFieldExportButton('buttons-before-left'));
-
-        /** @var GridFieldDetailForm $detailForm */
-        $detailForm = $memberListConfig->getComponentByType(GridFieldDetailForm::class);
-        $memberValidator = Member::singleton()->getValidator();
-        $detailForm->setValidator($memberValidator);
-
-        /** @var GridFieldPageCount $groupPaginator */
-        $groupListConfig->removeComponentsByType(GridFieldPageCount::class);
-        $groupListConfig->addComponent(new GridFieldPageCount('buttons-before-right'));
-
-        // Add import capabilities. Limit to admin since the import logic can affect assigned permissions
-        if (Permission::check('ADMIN')) {
-            // @todo when grid field is converted to react use the react component
-            $memberListConfig->addComponent(
-                GridFieldImportButton::create('buttons-before-left')
-                    ->setImportIframe($this->Link('memberimport'))
-                    ->setModalTitle(_t(__CLASS__ . '.IMPORTUSERS', 'Import users'))
-            );
-            $groupListConfig->addComponent(
-                GridFieldImportButton::create('buttons-before-left')
-                    ->setImportIframe($this->Link('groupimport'))
-                    ->setModalTitle(_t(__CLASS__ . '.IMPORTGROUPS', 'Import groups'))
-            );
-        }
-
-        // Build gridfield
-        $memberList = GridField::create(
-            'Members',
-            false,
-            Member::get(),
-            $memberListConfig
-        )->addExtraClass("members_grid");
-
-        // Build group fields
-        $groupList = GridField::create(
-            'Groups',
-            false,
-            Group::get(),
-            $groupListConfig
-        );
-        /** @var GridFieldDataColumns $columns */
-        $columns = $groupList->getConfig()->getComponentByType(GridFieldDataColumns::class);
-        $columns->setDisplayFields(array(
-            'Breadcrumbs' => Group::singleton()->fieldLabel('Title')
-        ));
-        $columns->setFieldFormatting(array(
-            'Breadcrumbs' => function ($val, $item) {
-                /** @var Group $item */
-                return Convert::raw2xml($item->getBreadcrumbs(' > '));
-            }
-        ));
-
-        $fields = FieldList::create(
-            TabSet::create(
-                'Root',
-                Tab::create(
-                    'Users',
-                    _t(__CLASS__ . '.Users', 'Users'),
-                    LiteralField::create(
-                        'MembersCautionText',
-                        sprintf(
-                            '<div class="alert alert-warning" role="alert">%s</div>',
-                            _t(
-                                __CLASS__ . '.MemberListCaution',
-                                'Caution: Removing members from this list will remove them from all groups and the database'
-                            )
-                        )
-                    ),
-                    $memberList
-                ),
-                Tab::create(
-                    'Groups',
-                    Group::singleton()->i18n_plural_name(),
-                    $groupList
-                )
-            )->setTemplate('SilverStripe\\Forms\\CMSTabSet'),
-            // necessary for tree node selection in LeftAndMain.EditForm.js
-            new HiddenField('ID', false, 0)
-        );
-
-        // Add roles editing interface
-        $rolesTab = null;
-        if (Permission::check('APPLY_ROLES')) {
-            $rolesField = GridField::create(
-                'Roles',
-                false,
-                PermissionRole::get(),
-                GridFieldConfig_RecordEditor::create()
-            );
-
-            $rolesTab = $fields->findOrMakeTab('Root.Roles', _t(__CLASS__ . '.TABROLES', 'Roles'));
-            $rolesTab->push($rolesField);
-        }
-
-        // Build replacement form
-        $form = Form::create(
-            $this,
-            'EditForm',
-            $fields,
-            new FieldList()
-        )->setHTMLID('Form_EditForm');
-        $form->addExtraClass('cms-edit-form fill-height');
-        $form->setTemplate($this->getTemplatesWithSuffix('_EditForm'));
-        $form->addExtraClass('ss-tabset cms-tabset ' . $this->BaseCSSClasses());
-        $form->setAttribute('data-pjax-fragment', 'CurrentForm');
-
-        $this->extend('updateEditForm', $form);
-
-        return $form;
-    }
-
-    public function memberimport()
-    {
-        Requirements::clear();
-        Requirements::javascript('silverstripe/admin: client/dist/js/vendor.js');
-        Requirements::javascript('silverstripe/admin: client/dist/js/MemberImportForm.js');
-        Requirements::css('silverstripe/admin: client/dist/styles/bundle.css');
-
-        return $this->renderWith('BlankPage', array(
-            'Form' => $this->MemberImportForm()->forTemplate(),
-            'Content' => ' '
-        ));
-    }
-
-    /**
-     * @see SecurityAdmin_MemberImportForm
-     *
-     * @return Form
-     */
-    public function MemberImportForm()
-    {
-        if (!Permission::check('ADMIN')) {
-            return null;
-        }
-
-        /** @var Group $group */
-        $group = $this->currentPage();
-        $form = new MemberImportForm($this, __FUNCTION__);
-        $form->setGroup($group);
-
-        return $form;
-    }
-
-    public function groupimport()
-    {
-        Requirements::clear();
-        Requirements::javascript('silverstripe/admin: client/dist/js/vendor.js');
-        Requirements::javascript('silverstripe/admin: client/dist/js/MemberImportForm.js');
-        Requirements::css('silverstripe/admin: client/dist/styles/bundle.css');
-
-        return $this->renderWith('BlankPage', array(
-            'Content' => ' ',
-            'Form' => $this->GroupImportForm()->forTemplate()
-        ));
-    }
-
-    /**
-     * @see SecurityAdmin_MemberImportForm
-     *
-     * @skipUpgrade
-     * @return Form
-     */
-    public function GroupImportForm()
-    {
-        if (!Permission::check('ADMIN')) {
-            return null;
-        }
-
-        return new GroupImportForm($this, __FUNCTION__);
-    }
-
-    /**
-     * Disable GridFieldDetailForm backlinks for this view, as its
-     */
-    public function Backlink()
-    {
-        return false;
-    }
-
-    public function Breadcrumbs($unlinked = false)
-    {
-        $crumbs = parent::Breadcrumbs($unlinked);
-
-        // Name root breadcrumb based on which record is edited,
-        // which can only be determined by looking for the fieldname of the GridField.
-        // Note: Titles should be same titles as tabs in RootForm().
-        $params = $this->getRequest()->allParams();
-        if (isset($params['FieldName'])) {
-            // TODO FieldName param gets overwritten by nested GridFields,
-            // so shows "Members" rather than "Groups" for the following URL:
-            // admin/security/EditForm/field/Groups/item/2/ItemEditForm/field/Members/item/1/edit
-            $firstCrumb = $crumbs->shift();
-            if ($params['FieldName'] == 'Groups') {
-                $crumbs->unshift(new ArrayData(array(
-                    'Title' => Group::singleton()->i18n_plural_name(),
-                    'Link' => $this->Link('groups')
-                )));
-            } elseif ($params['FieldName'] == 'Users') {
-                $crumbs->unshift(new ArrayData(array(
-                    'Title' => _t(__CLASS__ . '.Users', 'Users'),
-                    'Link' => $this->Link('users')
-                )));
-            } elseif ($params['FieldName'] == 'Roles') {
-                $crumbs->unshift(new ArrayData(array(
-                    'Title' => _t(__CLASS__ . '.TABROLES', 'Roles'),
-                    'Link' => $this->Link('roles')
-                )));
-            }
-            $crumbs->unshift($firstCrumb);
-        }
-
-        return $crumbs;
     }
 
     public function providePermissions()

--- a/tests/behat/features/manage-users.feature
+++ b/tests/behat/features/manage-users.feature
@@ -4,6 +4,7 @@ Feature: Manage users
   I want to create and manage user accounts on my site
   So that I can control access to the CMS
 
+
   Background:
     Given a "member" "ADMIN" belonging to "ADMIN group" with "Email"="admin@example.org"
     And the "member" "ADMIN" belonging to "ADMIN group2"
@@ -14,70 +15,69 @@ Feature: Manage users
     And I am logged in with "ADMIN" permissions
     And I go to "/admin/security"
 
-
   Scenario: I cannot remove my admin access, but can remove myself from an admin group
     When I click the "Groups" CMS tab
-      And I click "ADMIN group" in the "#Root_Groups" element
+      And I click "ADMIN group" in the "#Form_EditForm_SilverStripe-Security-Group" element
       And I should see the "Unlink" button in the "Members" gridfield for the "ADMIN" row
     Then I click "Groups" in the ".breadcrumbs-wrapper" element
       And I click the "Groups" CMS tab
-      And I click "ADMIN group2" in the "#Root_Groups" element
+      And I click "ADMIN group2" in the "#Form_EditForm_SilverStripe-Security-Group" element
       And I should see the "Unlink" button in the "Members" gridfield for the "ADMIN" row
     Then I click the "Unlink" button in the "Members" gridfield for the "ADMIN" row
       And I should not see the "Unlink" button in the "Members" gridfield for the "ADMIN" row
     Then I click "Groups" in the ".breadcrumbs-wrapper" element
       And I click the "Groups" CMS tab
-      And I click "ADMIN group" in the "#Root_Groups" element
+      And I click "ADMIN group" in the "#Form_EditForm_SilverStripe-Security-Group" element
       And I should not see the "Unlink" button in the "Members" gridfield for the "ADMIN" row
 
   Scenario: I can list all users regardless of group
-    When I click the "Users" CMS tab
-    Then I should see "admin@example.org" in the "#Root_Users" element
-    And I should see "staffmember@example.org" in the "#Root_Users" element
+    When I click the "Members" CMS tab
+    Then I should see "admin@example.org" in the "#Form_EditForm_SilverStripe-Security-Member" element
+    And I should see "staffmember@example.org" in the "#Form_EditForm_SilverStripe-Security-Member" element
 
   Scenario: I can search for an existing user by name
-    When I click the "Users" CMS tab
+    When I click the "Members" CMS tab
     And I press the "Open search and filter" button
     And I fill in "SearchBox__FirstName" with "ADMIN"
     And I press the "Enter" key in the "SearchBox__FirstName" field
-    Then I should see "admin@example.org" in the "#Root_Users" element
-    But I should not see "staffmember@example.org" in the "#Root_Users" element
+    Then I should see "admin@example.org" in the "#Form_EditForm_SilverStripe-Security-Member" element
+    But I should not see "staffmember@example.org" in the "#Form_EditForm_SilverStripe-Security-Member" element
     # Required to avoid "unsaved changes" browser dialog
     Then I press the "Close" button
 
   Scenario: I can search for an existing user by email
-    When I click the "Users" CMS tab
+    When I click the "Members" CMS tab
     And I press the "Open search and filter" button
     And I press the "Advanced" button
     And I fill in "Search__Email" with "staffmember@example.org"
     And I press the "Search" button
-    Then I should see "staffmember@example.org" in the "#Root_Users" element
-    But I should not see "admin@example.org" in the "#Root_Users" element
+    Then I should see "staffmember@example.org" in the "#Form_EditForm_SilverStripe-Security-Member" element
+    But I should not see "admin@example.org" in the "#Form_EditForm_SilverStripe-Security-Member" element
     # Required to avoid "unsaved changes" browser dialog
     Then I press the "Close" button
 
   Scenario: I can clear a search for an existing user
-    Given I click the "Users" CMS tab
+    Given I click the "Members" CMS tab
     And I press the "Open search and filter" button
     And I press the "Advanced" button
     And I fill in "Search__Email" with "staffmember@example.org"
     And I press the "Search" button
-    And I should see "staffmember@example.org" in the "#Root_Users" element
-    And I should not see "admin@example.org" in the "#Root_Users" element
+    And I should see "staffmember@example.org" in the "#Form_EditForm_SilverStripe-Security-Member" element
+    And I should not see "admin@example.org" in the "#Form_EditForm_SilverStripe-Security-Member" element
     When I press the "Close" button
     Then I should see a "Open search and filter" button
-    And I should see "staffmember@example.org" in the "#Root_Users" element
-    And I should see "admin@example.org" in the "#Root_Users" element
+    And I should see "staffmember@example.org" in the "#Form_EditForm_SilverStripe-Security-Member" element
+    And I should see "admin@example.org" in the "#Form_EditForm_SilverStripe-Security-Member" element
 
   Scenario: I can list all users in a specific group
     When I click the "Groups" CMS tab
     # TODO Please check how performant this is
-    And I click "ADMIN group" in the "#Root_Groups" element
+    And I click "ADMIN group" in the "#Form_EditForm_SilverStripe-Security-Group" element
     Then I should see "admin@example.org" in the "#Root_Members" element
     And I should not see "staffmember@example.org" in the "#Root_Members" element
 
   Scenario: I can add a user to the system
-    When I click the "Users" CMS tab
+    When I click the "Members" CMS tab
     And I press the "Add Member" button
     And I fill in the following:
       | First Name | John |
@@ -87,18 +87,18 @@ Feature: Manage users
     Then I should see a "Saved member" message
 
     When I go to "admin/security/"
-    Then I should see "john.doe@example.org" in the "#Root_Users" element
+    Then I should see "john.doe@example.org" in the "#Form_EditForm_SilverStripe-Security-Member" element
 
   @modal
   Scenario: I can navigate users from the edit form and retain my search query
-    When I click the "Users" CMS tab
+    When I click the "Members" CMS tab
     And I press the "First Name" button
 
-    Then I should see "admin@example.org" in the "#Root_Users" element
-    And I should see "othermember@example.org" in the "#Root_Users" element
-    And I should see "staffmember@example.org" in the "#Root_Users" element
+    Then I should see "admin@example.org" in the "#Form_EditForm_SilverStripe-Security-Member" element
+    And I should see "othermember@example.org" in the "#Form_EditForm_SilverStripe-Security-Member" element
+    And I should see "staffmember@example.org" in the "#Form_EditForm_SilverStripe-Security-Member" element
 
-    When I click "othermember@example.org" in the "#Root_Users" element
+    When I click "othermember@example.org" in the "#Form_EditForm_SilverStripe-Security-Member" element
     And I follow "Go to next record"
     Then the "Email" field should contain "staffmember@example.org"
 
@@ -114,20 +114,20 @@ Feature: Manage users
 
   Scenario: I can edit an existing user and add him to an existing group
     When I go to "admin/security/"
-    And I click the "Users" CMS tab
-    And I click "staffmember@example.org" in the "#Root_Users" element
+    And I click the "Members" CMS tab
+    And I click "staffmember@example.org" in the "#Form_EditForm_SilverStripe-Security-Member" element
     And I select "ADMIN group" from "Groups"
     And I press the "Apply changes|Save" buttons
     Then I should see a "Saved Member" message
 
     When I go to "admin/security"
     And I click the "Groups" CMS tab
-    And I click "ADMIN group" in the "#Root_Groups" element
+    And I click "ADMIN group" in the "#Form_EditForm_SilverStripe-Security-Group" element
     Then I should see "staffmember@example.org"
 
   Scenario: I can delete an existing user
-    When I click the "Users" CMS tab
-    And I click "staffmember@example.org" in the "#Root_Users" element
+    When I click the "Members" CMS tab
+    And I click "staffmember@example.org" in the "#Form_EditForm_SilverStripe-Security-Member" element
     And I press the "Delete" button, confirming the dialog
     Then I should see "admin@example.org"
     And I should not see "staffmember@example.org"

--- a/tests/php/SecurityAdminTest.php
+++ b/tests/php/SecurityAdminTest.php
@@ -55,7 +55,8 @@ class SecurityAdminTest extends FunctionalTest
         $group = $this->objFromFixture(Group::class, 'admin');
 
         Config::modify()->merge(Permission::class, 'hidden_permissions', array('CMS_ACCESS_ReportAdmin'));
-        $response = $this->get(sprintf('admin/security/EditForm/field/Groups/item/%d/edit', $group->ID));
+//        $response = $this->get(sprintf('admin/security/EditForm/field/Groups/item/%d/edit', $group->ID));
+        $response = $this->get(sprintf('/admin/security/SilverStripe-Security-Group/EditForm/field/SilverStripe-Security-Group/item/%d/edit', $group->ID));
 
         $this->assertContains(
             'CMS_ACCESS_SecurityAdmin',


### PR DESCRIPTION
This is a bit experimental. It converts SecurityAdmin to be a ModelAdmin.

It seems to work remarkably well. If we think this is worthwhile, we can take it forward and finalise it.

Couple things to address:
* Rename Members to Users ... that is if we prefer that label.
* Bring back the "Caution: Removing members from this list will remove them from all groups and the database"
* I think there's a bit of custom import logic that I didn't copy over. I need to dig deeper and see if differs from the boiler plate ModelAdmin import logic.
* Clean up any redundant JS and SS files

## Parent issue
- https://github.com/silverstripe/silverstripe-admin/issues/1350