### PR TITLE
BUG Lowercase PHPUnit in composer.json to allow packagist to resolve 1.2.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {
-        "phpunit/PHPUnit": "^5.7"
+        "phpunit/phpunit": "^5.7"
     },
     "extra": {
         "expose": [


### PR DESCRIPTION
Packagist doesn't like it when dependencies are not all written in lowercase. This is preventing it to resolve 1.2.x-dev as an alias for 1.2.x-dev.