### PR TITLE
API Break up ModelAdmin::getEditForm into getGridField and getGridFieldConfig

### DIFF
--- a/code/ModelAdmin.php
+++ b/code/ModelAdmin.php
@@ -15,6 +15,7 @@ use SilverStripe\Forms\FileField;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldConfig;
 use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\Forms\GridField\GridFieldDetailForm;
 use SilverStripe\Forms\GridField\GridFieldExportButton;
@@ -177,65 +178,10 @@ abstract class ModelAdmin extends LeftAndMain
      */
     public function getEditForm($id = null, $fields = null)
     {
-        $list = $this->getList();
-        $exportButton = new GridFieldExportButton('buttons-before-left');
-        $exportButton->setExportColumns($this->getExportFields());
-        $listField = GridField::create(
-            $this->sanitiseClassName($this->modelClass),
-            false,
-            $list,
-            $fieldConfig = GridFieldConfig_RecordEditor::create($this->config()->get('page_length'))
-                ->addComponent($exportButton)
-                ->addComponents(new GridFieldPrintButton('buttons-before-left'))
-        );
-
-        // Remove default and add our own filter header with extension points
-        // to retain API until deprecation in 5.0
-        $listField->getConfig()->removeComponentsByType(GridFieldFilterHeader::class);
-        $listField->getConfig()->addComponent(new GridFieldFilterHeader(
-            false,
-            function ($context) {
-                 $this->extend('updateSearchContext', $context);
-            },
-            function ($form) {
-                $this->extend('updateSearchForm', $form);
-            }
-        ));
-
-        // GridFieldPaginator has to be added after filter header for it to function correctly
-        $paginator = $listField->getConfig()->getComponentByType(GridFieldPaginator::class);
-        if ($paginator) {
-            $listField->getConfig()
-                ->removeComponent($paginator)
-                ->addComponent($paginator);
-        }
-
-        if (!$this->showSearchForm ||
-            (is_array($this->showSearchForm) && !in_array($this->modelClass, $this->showSearchForm))
-        ) {
-            $listField->getConfig()->removeComponentsByType(GridFieldFilterHeader::class);
-        }
-
-        // Validation
-        if (singleton($this->modelClass)->hasMethod('getCMSValidator')) {
-            $detailValidator = singleton($this->modelClass)->getCMSValidator();
-            /** @var GridFieldDetailForm $detailform */
-            $detailform = $listField->getConfig()->getComponentByType(GridFieldDetailForm::class);
-            $detailform->setValidator($detailValidator);
-        }
-
-        if ($this->showImportForm) {
-            $fieldConfig->addComponent(
-                GridFieldImportButton::create('buttons-before-left')
-                    ->setImportForm($this->ImportForm())
-                    ->setModalTitle(_t('SilverStripe\\Admin\\ModelAdmin.IMPORT', 'Import from CSV'))
-            );
-        }
-
         $form = Form::create(
             $this,
             'EditForm',
-            new FieldList($listField),
+            new FieldList($this->getGridField()),
             new FieldList()
         )->setHTMLID('Form_EditForm');
         $form->addExtraClass('cms-edit-form cms-panel-padded center flexbox-area-grow');
@@ -247,6 +193,88 @@ abstract class ModelAdmin extends LeftAndMain
         $this->extend('updateEditForm', $form);
 
         return $form;
+    }
+
+    /**
+     * Generate the GridField field that will be used for this ModelAdmin.
+     *
+     * Developers may override this method in their ModelAdmin class to customise their GridField.
+     *
+     * @see {@link getGridFieldConfig()}
+     * @return GridField
+     */
+    protected function getGridField(): GridField
+    {
+        return GridField::create(
+            $this->sanitiseClassName($this->modelClass),
+            false,
+            $this->getList(),
+            $this->getGridFieldConfig()
+        );
+    }
+
+    /**
+     * Generate the GridField Configuration that will use for the ModelAdmin Gridfield.
+     *
+     * Developers may override this method in their ModelAdmin class to customise their GridFieldConfiguration.
+     *
+     * @return GridFieldConfig
+     */
+    protected function getGridFieldConfig(): GridFieldConfig
+    {
+        $config = GridFieldConfig_RecordEditor::create($this->config()->get('page_length'));
+
+        $exportButton = new GridFieldExportButton('buttons-before-left');
+        $exportButton->setExportColumns($this->getExportFields());
+
+        $config
+            ->addComponent($exportButton)
+            ->addComponents(new GridFieldPrintButton('buttons-before-left'));
+
+        // Remove default and add our own filter header with extension points
+        // to retain API until deprecation in 5.0
+        $config->removeComponentsByType(GridFieldFilterHeader::class);
+        $config->addComponent(new GridFieldFilterHeader(
+            false,
+            function ($context) {
+                $this->extend('updateSearchContext', $context);
+            },
+            function ($form) {
+                $this->extend('updateSearchForm', $form);
+            }
+        ));
+
+        // GridFieldPaginator has to be added after filter header for it to function correctly
+        $paginator = $config->getComponentByType(GridFieldPaginator::class);
+        if ($paginator) {
+            $config
+                ->removeComponent($paginator)
+                ->addComponent($paginator);
+        }
+
+        if (!$this->showSearchForm ||
+            (is_array($this->showSearchForm) && !in_array($this->modelClass, $this->showSearchForm))
+        ) {
+            $config->removeComponentsByType(GridFieldFilterHeader::class);
+        }
+
+        // Validation
+        if (singleton($this->modelClass)->hasMethod('getCMSValidator')) {
+            $detailValidator = singleton($this->modelClass)->getCMSValidator();
+            /** @var GridFieldDetailForm $detailform */
+            $detailform = $config->getComponentByType(GridFieldDetailForm::class);
+            $detailform->setValidator($detailValidator);
+        }
+
+        if ($this->showImportForm) {
+            $config->addComponent(
+                GridFieldImportButton::create('buttons-before-left')
+                    ->setImportForm($this->ImportForm())
+                    ->setModalTitle(_t('SilverStripe\\Admin\\ModelAdmin.IMPORT', 'Import from CSV'))
+            );
+        }
+
+        return $config;
     }
 
     /**

--- a/tests/php/ModelAdminTest.php
+++ b/tests/php/ModelAdminTest.php
@@ -4,6 +4,10 @@ namespace SilverStripe\Admin\Tests;
 
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Session;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldExportButton;
+use SilverStripe\Forms\GridField\GridFieldImportButton;
+use SilverStripe\Forms\GridField\GridFieldPrintButton;
 use SilverStripe\Security\Permission;
 use SilverStripe\Dev\FunctionalTest;
 
@@ -13,7 +17,8 @@ class ModelAdminTest extends FunctionalTest
 
     protected static $extra_dataobjects = [
         ModelAdminTest\Contact::class,
-        ModelAdminTest\Player::class
+        ModelAdminTest\Player::class,
+        ModelAdminTest\OverridenModelAdmin::class
     ];
 
     protected static $extra_controllers = [
@@ -53,5 +58,72 @@ class ModelAdminTest extends FunctionalTest
             'Name' => 'Name',
             'Position' => 'Position'
         ));
+    }
+
+    public function testGetGridField()
+    {
+        $admin = new ModelAdminTest\OverridenModelAdmin();
+        $request = new HTTPRequest('GET', '/');
+        $request->setSession(new Session([]));
+        $admin->setRequest($request);
+        $admin->doInit();
+
+        // Test the call counts
+        $this->assertEquals(
+            [
+                'getGridField' => 0,
+                'getGridFieldConfig' => 0,
+                'updateGridField' => 0,
+                'updateGridFieldConfig' => 0,
+            ],
+            $admin->calls,
+            'Before calling Edit Form, all our call counts are zero'
+        );
+
+        $form = $admin->getEditForm();
+
+        $this->assertEquals(
+            [
+                'getGridField' => 1,
+                'getGridFieldConfig' => 1,
+                'updateGridField' => 1,
+                'updateGridFieldConfig' => 1,
+            ],
+            $admin->calls,
+            'All protected method and extension points have been called once.'
+        );
+
+        // Test the GridField generation
+        /** @var GridField $field */
+        $field = $form->Fields()->fieldByName('SilverStripe-Admin-Tests-ModelAdminTest-Player');
+        $this->assertNotNull($field, 'A GridField has been found on the form.');
+
+        $this->assertContains(
+            'OverridenModelAdmin',
+            $field->extraClass(),
+            'OverridenModelAdmin has added an extra class to the grid field'
+        );
+        $this->assertContains(
+            'called',
+            $field->getAttribute('ModelAdminExtension'),
+            'ModelAdminExtension has added an attribute to the GridField'
+        );
+
+        // Test the GridField Config
+        $config = $field->getConfig();
+        $this->assertEmpty(
+            $config->getComponentByType(GridFieldExportButton::class),
+            'OverridenModelAdmin removes the Export Button'
+        );
+
+        $this->assertEmpty(
+            $config->getComponentByType(GridFieldPrintButton::class),
+            'ModelAdminExtension removes the Print Button'
+        );
+
+        $this->assertNotEmpty(
+            $config->getComponentByType(GridFieldImportButton::class),
+            'The import button is still there'
+        );
     }
 }

--- a/tests/php/ModelAdminTest/ModelAdminExtension.php
+++ b/tests/php/ModelAdminTest/ModelAdminExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SilverStripe\Admin\Tests\ModelAdminTest;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldConfig;
+use SilverStripe\Forms\GridField\GridFieldExportButton;
+
+/**
+ * This ModelAdmin is specifically designed to test that Model Admin behaves has expected when
+ * getGridField and getGridFieldConfig are called.
+ */
+class ModelAdminExtension extends Extension implements TestOnly
+{
+
+    public function updateGridField(GridField &$field)
+    {
+        $this->getOwner()->calls[__FUNCTION__]++;
+        $field->setAttribute('ModelAdminExtension', 'called');
+    }
+
+    public function updateGridFieldConfig(GridFieldConfig &$config)
+    {
+        $this->getOwner()->calls[__FUNCTION__]++;
+        $config->removeComponentsByType(GridFieldExportButton::class);
+    }
+}

--- a/tests/php/ModelAdminTest/OverridenModelAdmin.php
+++ b/tests/php/ModelAdminTest/OverridenModelAdmin.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace SilverStripe\Admin\Tests\ModelAdminTest;
+
+use SilverStripe\Admin\ModelAdmin;
+use SilverStripe\Control\Controller;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldConfig;
+use SilverStripe\Forms\GridField\GridFieldPrintButton;
+
+/**
+ * This ModelAdmin is specifically designed to test that Model Admin behaves as expected when getGridField and
+ * getGridFieldConfig are called.
+ *
+ * The `$calls` attribute count the number of time each protected methods has been called.
+ *
+ * `getGridField` adds an extra class to the grid field and the `updateGridField` hook adds an attribute.
+ *
+ * `getGridFieldConfig` removes the Print component and the `updateGridField` hook removes the Export component
+ */
+class OverridenModelAdmin extends ModelAdmin implements TestOnly
+{
+    private static $url_segment = 'overriden-admin';
+
+    private static $managed_models = [
+        Player::class
+    ];
+
+    private static $extensions = [
+        ModelAdminExtension::class
+    ];
+
+    /**
+     * @var array Number of times the protected gridfield and gridfield config method and related hooks have been
+     * called.
+     */
+    public $calls = [
+        'getGridField' => 0,
+        'getGridFieldConfig' => 0,
+        'updateGridField' => 0,
+        'updateGridFieldConfig' => 0,
+    ];
+
+
+    protected function getGridField(): GridField
+    {
+        $this->calls[__FUNCTION__]++;
+
+        $field = parent::getGridField();
+
+        $field->addExtraClass('OverridenModelAdmin');
+
+        return $field;
+    }
+
+    protected function getGridFieldConfig(): GridFieldConfig
+    {
+        $this->calls[__FUNCTION__]++;
+        $config = parent::getGridFieldConfig();
+        $config->removeComponentsByType(GridFieldPrintButton::class);
+        return $config;
+    }
+}


### PR DESCRIPTION
This is a sort of RFC/PR.

Many times over the years, I wanted to do a minor tweak to a ModelAdmin gridfield. However, to actually get to the instance of your GridiField, you got to override getEditForm and then fetch your gridfield instance, which will have a different name base on what model the user is currently viewing.

Basically it's unruly and not a very nice developer experience.

My thinking is let's split the ModelAdmin `getEditForm` method into smaller protected methods which will allow developers to override the specific bits they want to customise:
* `getGridField` for the actual field ;
* `getGridFieldConfig` for the config part.

As an added benefit, I also think this makes the code more readable.

We might also want to add a few extra extension points for Extensions to hook into.

Following our wonderful discussion about "public vs private vs protected", I think those new methods should be considered part of our official API. I haven't written unit tests for them.

The point of this PR is to demonstrate that this change is pretty trivial and compatible with Semver. If people think this is worthwhile, I can add some unit tests to for the new protected methods.

# Related PR
* https://github.com/silverstripe/silverstripe-framework/pull/9334 (adds relevant doc)