### PR TITLE
BUG case error in SelectionGroup template

### DIFF
--- a/themes/cms-forms/templates/SilverStripe/Forms/SelectionGroup.ss
+++ b/themes/cms-forms/templates/SilverStripe/Forms/SelectionGroup.ss
@@ -23,7 +23,7 @@
 				<% if $FieldList %>
 					<div class="selection-group selection-group__item__fieldlist" id="$ID">
 						<% loop $FieldList %>
-							$Fieldholder
+							$FieldHolder
 						<% end_loop %>
 					</div>
 				<% end_if %>


### PR DESCRIPTION
The SelectionGroup template uses `$Fieldholder` which does get the result of the `FieldHolder` method but doesn't get automatically cast to `HTMLFragment` because casting is case-sensitive. This fixes that.