### PR TITLE
DEPENDENCY: Replace getCMSValidator with new framework method getCompositeValidator

### DIFF
--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -1442,7 +1442,7 @@ class LeftAndMain extends Controller implements PermissionProvider
         $form->addExtraClass('fill-height');
 
         // A CompositeValidator is always available form a DataObject, but it may be empty (which is fine)
-        $form->setValidator($record->getCompositeValidator());
+        $form->setValidator($record->getCMSCompositeValidator());
 
         // Check if this form is readonly
         if (!$record->canEdit()) {

--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -1441,8 +1441,8 @@ class LeftAndMain extends Controller implements PermissionProvider
         }
         $form->addExtraClass('fill-height');
 
-        // A ValidatorList is always available form a DataObject, but it may be empty (which is fine)
-        $form->setValidator($record->getValidatorList());
+        // A CompositeValidator is always available form a DataObject, but it may be empty (which is fine)
+        $form->setValidator($record->getCompositeValidator());
 
         // Check if this form is readonly
         if (!$record->canEdit()) {

--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -1441,18 +1441,8 @@ class LeftAndMain extends Controller implements PermissionProvider
         }
         $form->addExtraClass('fill-height');
 
-        // Add a default or custom validator.
-        if ($record->hasMethod('getCMSValidator')) {
-            $validator = $record->getCMSValidator();
-            // The clientside (mainly LeftAndMain*.js) rely on ajax responses
-            // which can be evaluated as javascript, hence we need
-            // to override any global changes to the validation handler.
-            if ($validator) {
-                $form->setValidator($validator);
-            }
-        } else {
-            $form->unsetValidator();
-        }
+        // A ValidatorList is always available form a DataObject, but it may be empty (which is fine)
+        $form->setValidator($record->getValidatorList());
 
         // Check if this form is readonly
         if (!$record->canEdit()) {

--- a/code/ModelAdmin.php
+++ b/code/ModelAdmin.php
@@ -265,8 +265,8 @@ abstract class ModelAdmin extends LeftAndMain
         }
 
         // Validation
-        if (singleton($this->modelClass)->hasMethod('getCMSValidator')) {
-            $detailValidator = singleton($this->modelClass)->getCMSValidator();
+        if (singleton($this->modelClass)->hasMethod('getValidatorList')) {
+            $detailValidator = singleton($this->modelClass)->getValidatorList();
             /** @var GridFieldDetailForm $detailform */
             $detailform = $config->getComponentByType(GridFieldDetailForm::class);
             $detailform->setValidator($detailValidator);

--- a/code/ModelAdmin.php
+++ b/code/ModelAdmin.php
@@ -265,8 +265,8 @@ abstract class ModelAdmin extends LeftAndMain
         }
 
         // Validation
-        if (singleton($this->modelClass)->hasMethod('getCompositeValidator')) {
-            $detailValidator = singleton($this->modelClass)->getCompositeValidator();
+        if (singleton($this->modelClass)->hasMethod('getCMSCompositeValidator')) {
+            $detailValidator = singleton($this->modelClass)->getCMSCompositeValidator();
             /** @var GridFieldDetailForm $detailform */
             $detailform = $config->getComponentByType(GridFieldDetailForm::class);
             $detailform->setValidator($detailValidator);

--- a/code/ModelAdmin.php
+++ b/code/ModelAdmin.php
@@ -265,8 +265,8 @@ abstract class ModelAdmin extends LeftAndMain
         }
 
         // Validation
-        if (singleton($this->modelClass)->hasMethod('getValidatorList')) {
-            $detailValidator = singleton($this->modelClass)->getValidatorList();
+        if (singleton($this->modelClass)->hasMethod('getCompositeValidator')) {
+            $detailValidator = singleton($this->modelClass)->getCompositeValidator();
             /** @var GridFieldDetailForm $detailform */
             $detailform = $config->getComponentByType(GridFieldDetailForm::class);
             $detailform->setValidator($detailValidator);


### PR DESCRIPTION
# Dependent PRs (to be merge before this)

- [x] https://github.com/silverstripe/silverstripe-framework/pull/9406

# Change

As part of the above PR, there is now a standardised method (`getValidatorList()`) for adding/manipulating `Validators` for a `DataObject`.

This new method provides BC for the old `getCMSValidator()` method.

# Tests

Tests are expectedly failing, as I have replaced call to `getCMSValidator()` with `getValidatorList()`, which won't exist until the above dependent PR has been merged.

I have, however, run the tests locally (with the dependent PR checked out), and all tests are currently passing.

![Screen Shot 2020-02-19 at 11 26 03 AM](https://user-images.githubusercontent.com/505788/74784162-314c0500-530c-11ea-9ca0-5abfa0c794ef.png)