### PR TITLE
FIX "My profile" title in CMS is now vertical centered as other LeftAndMain screens are

### DIFF
--- a/templates/SilverStripe/Admin/Includes/CMSProfileController_Content.ss
+++ b/templates/SilverStripe/Admin/Includes/CMSProfileController_Content.ss
@@ -1,8 +1,8 @@
 <div id="settings-controller-cms-content" class="cms-content cms-tabset flexbox-area-grow fill-height $BaseCSSClasses" data-layout-type="border" data-pjax-fragment="Content">
 
-	<div class="cms-content-header vertical-align-items">
+	<div class="cms-content-header north vertical-align-items">
 		<% with $EditForm %>
-			<div class="cms-content-header-info flexbox-area-grow">
+			<div class="cms-content-header-info flexbox-area-grow vertical-align-items">
 				<% with $Controller %>
 					<% include SilverStripe\\Admin\\CMSBreadcrumbs %>
 				<% end_with %>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5170590/77271730-a3e23480-6c6c-11ea-9f6a-35abcf0fd92b.png)

After:
![image](https://user-images.githubusercontent.com/5170590/77271748-afcdf680-6c6c-11ea-8017-93b98e2cc689.png)
