### PR TITLE
ENH Make CMSProfileController use required_permission_codes

### DIFF
--- a/code/CMSProfileController.php
+++ b/code/CMSProfileController.php
@@ -18,7 +18,7 @@ class CMSProfileController extends LeftAndMain
 
     private static $menu_title = 'My Profile';
 
-    private static $required_permission_codes = false;
+    private static $required_permission_codes = 'CMS_ACCESS';
 
     private static $tree_class = Member::class;
 
@@ -59,8 +59,10 @@ class CMSProfileController extends LeftAndMain
 
     public function canView($member = null)
     {
+        $currentUser = Security::getCurrentUser();
+
         if (!$member && $member !== false) {
-            $member = Security::getCurrentUser();
+            $member = $currentUser;
         }
 
         // cms menus only for logged-in members
@@ -68,14 +70,8 @@ class CMSProfileController extends LeftAndMain
             return false;
         }
 
-        // Check they can access the CMS and that they are trying to edit themselves
-        if (Permission::checkMember($member, "CMS_ACCESS")
-            && $member->ID === Security::getCurrentUser()->ID
-        ) {
-            return true;
-        }
-
-        return false;
+        // Check they are trying to edit themselves and they have permissions
+        return $member->ID === $currentUser->ID && parent::canView($member);
     }
 
     public function save(array $data, Form $form): HTTPResponse


### PR DESCRIPTION
It appears that CMSProfileController is hardcoded to check for the permission "CMS_ACCESS", but this prevents updating permissions via _config/yaml files.

I've refactored the function to use the same permission login & incorporate the use of $required_permission_codes.

Any feedback welcome.

## Issue
- https://github.com/silverstripe/silverstripe-admin/issues/1537