### PR TITLE
Make LeftAndMain independent of the presence of Versioned module

### DIFF
--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -754,12 +754,12 @@ class LeftAndMain extends Controller implements PermissionProvider
         SSViewer::set_themes(LeftAndMain::config()->uninherited('admin_themes'));
         
         // Check the presence of Silverstripe-Versioned module
-        if(class_exists(Versioned::class)) {
-           // Set the current reading mode
-           Versioned::set_stage(Versioned::DRAFT);
-
-           // Set default reading mode to suppress ?stage=Stage querystring params in CMS
-           Versioned::set_default_reading_mode(Versioned::get_reading_mode());
+        if (class_exists(Versioned::class)) {
+            // Set the current reading mode
+            Versioned::set_stage(Versioned::DRAFT);
+            
+            // Set default reading mode to suppress ?stage=Stage querystring params in CMS
+            Versioned::set_default_reading_mode(Versioned::get_reading_mode());
         }
     }
 

--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -752,12 +752,15 @@ class LeftAndMain extends Controller implements PermissionProvider
 
         // Assign default cms theme and replace user-specified themes
         SSViewer::set_themes(LeftAndMain::config()->uninherited('admin_themes'));
+        
+        // Check the presence of Silverstripe-Versioned module
+        if(class_exists(Versioned::class)) {
+           // Set the current reading mode
+           Versioned::set_stage(Versioned::DRAFT);
 
-        // Set the current reading mode
-        Versioned::set_stage(Versioned::DRAFT);
-
-        // Set default reading mode to suppress ?stage=Stage querystring params in CMS
-        Versioned::set_default_reading_mode(Versioned::get_reading_mode());
+           // Set default reading mode to suppress ?stage=Stage querystring params in CMS
+           Versioned::set_default_reading_mode(Versioned::get_reading_mode());
+        }
     }
 
     public function handleRequest(HTTPRequest $request)


### PR DESCRIPTION
LeftAndMain's init() method calls two Versioned methods and this makes it impossible to have the Silverstripe-admin module installed without the Versioned module.

In other parts of the Silverstripe-admin code we have the verification of the presence or absence of the Versioned class, instead in the init() method it is missing.

Please, could you also introduce in the init() method the verification of the presence of the Versioned module in order to install the administrative panel without the Versioned module?

Like in the file commit, for example.