### PR TITLE
FIX: Ensure graphql URL is inserted before admin

### DIFF
--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -2,6 +2,8 @@
 Name: admin-graphql-routes
 Only:
   moduleexists: silverstripe/graphql
+Before:
+   - '#adminroutes'
 ---
 SilverStripe\Control\Director:
   rules:


### PR DESCRIPTION
I’ve had issues getting the URL admin/graphql to work on a ModelAdmin
app that doesn’t have CMS installed. This fix ensures that the graphql
URL rule is inserted before the admin one, making it work.