### PR TITLE
Implementation of horizontal scrolling in "ui-tabs-nav"

### DIFF
--- a/client/src/styles/legacy/_style.scss
+++ b/client/src/styles/legacy/_style.scss
@@ -148,8 +148,15 @@ html, body {
         height: $toolbar-height;
       }
     }
+    .ui-tabs-nav {
+      min-width: max-content;
+    }
 
     // CMS admin
+    .cms-content-header-tabs {
+      overflow: auto hidden;
+      white-space: nowrap;
+    }
     .cms-content-header-nav .breadcrumbs-wrapper,
     .cms-content-header-nav .cms-content-header-tabs,
       // Model admin


### PR DESCRIPTION
When a ModelAdmin has many tabs, as in the attached image, the controls for moving from one tab to another are arranged in another row.
With this patch the controls are kept horizontally and you can scroll to view the hidden ones.

Before:
![image](https://user-images.githubusercontent.com/17084152/85495061-1cdd8900-b5da-11ea-9799-9f10273e52f6.png)

After:
![image](https://user-images.githubusercontent.com/17084152/85495146-44ccec80-b5da-11ea-97e4-d6cd3e702134.png)
