### PR TITLE
FIX: Decouple ModelAdmin URL slug from class.

### DIFF
--- a/templates/SilverStripe/Admin/Includes/ModelAdmin_Content.ss
+++ b/templates/SilverStripe/Admin/Includes/ModelAdmin_Content.ss
@@ -16,7 +16,7 @@
 		<div class="cms-content-header-tabs cms-tabset-nav-primary ss-ui-tabs-nav">
 			<ul class="cms-tabset-nav-primary">
 				<% loop $ManagedModelTabs %>
-				<li class="tab-$ClassName $LinkOrCurrent<% if $LinkOrCurrent == 'current' %> ui-tabs-active<% end_if %>">
+				<li class="tab-$Tab $LinkOrCurrent<% if $LinkOrCurrent == 'current' %> ui-tabs-active<% end_if %>">
 					<a href="$Link" class="cms-panel-link" title="$Title.ATT">$Title</a>
 				</li>
 				<% end_loop %>


### PR DESCRIPTION
The default slug of a sanitised classname will still be in place, but
now the key can be set to a slug and the class provided in a dataClass
property.

This has a couple of benefits:

 - Slugs can be shorter (ModelAdmin URLs are verbose, to say the least)
 - The same class can be added to a ModelAdmin multiple times, for
   example with different filters.

If the dataClass is the same as the slug, backwards compatibility is
preserved. If the slug differs, then code that expected to find the
Slug in $this->modelClass will instead have to check $this->modelTab.

However, as this doesn’t break any upgrades (since the slug will never
differ on those) my view is that it’s minor-upgrade safe.