### PR TITLE
FIX: Fix ModelAdmin slug flex when getManagedModels() is overridden.

### DIFF
--- a/code/ModelAdmin.php
+++ b/code/ModelAdmin.php
@@ -154,7 +154,7 @@ abstract class ModelAdmin extends LeftAndMain
             $this->modelTab = key($models);
         }
 
-        $this->modelClass = $models[$this->modelTab]['dataClass'];
+        $this->modelClass = isset($models[$this->modelTab]['dataClass']) ? $models[$this->modelTab]['dataClass'] : $this->modelTab;
 
         // security check for valid models
         if (!array_key_exists($this->modelTab, $models)) {


### PR DESCRIPTION
The slug flexibility provided in #1072 introduced a bug, which this fixes:

The logic added to getManagedModels() won’t apply if the method is overridden and custom values returned

Note that the bug introduced in 1072 breaks ArchiveAdmin in versioned-admin.