### PR TITLE
NEW: Confirm PHP 8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .sass-cache
 /vendor/
+/resources/
 /node_modules/
 /**/*.js.map
 /**/*.css.map
@@ -7,3 +8,4 @@ yarn-error.log
 coverage/
 /storybook-static/
 /.storybook/.stories.js
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,17 +29,15 @@ matrix:
   fast_finish: true
   include:
     - php: 7.1
-      env: DB=PGSQL PHPUNIT_TEST=1
+      env: DB=PGSQL PHPUNIT_TEST=1 COMPOSER_ARG=--prefer-lowest
     - php: 7.2
       env: DB=MYSQL PHPUNIT_TEST=1 PHPCS_TEST=1
     - php: 7.3
-      env: DB=MYSQL PHPUNIT_TEST=1
+      env: DB=MYSQL PHPUNIT_TEST=1 PDO=1
     - php: 7.4
       env: DB=MYSQL PHPUNIT_TEST=1
-    - php: 7.1
-      env: DB=MYSQL PHPUNIT_TEST=1 PDO=1
-    - php: 7.2
-      env: DB=MYSQL PHPUNIT_TEST=1
+    - php: nightly
+      env: DB=MYSQL PHPUNIT_TEST=1 COMPOSER_ARG=--ignore-platform-reqs
     - php: 7.3
       env:
         - NPM_TEST=1
@@ -56,7 +54,7 @@ matrix:
 before_script:
 # Init PHP
   - export CORE_RELEASE=$TRAVIS_BRANCH
-  - printf "\n" | pecl install imagick
+  - if [ "$COMPOSER_ARG" != "--ignore-platform-reqs"]; then printf "\n" | pecl install imagick; fi
   - phpenv rehash
   - phpenv config-rm xdebug.ini || true
   - export PATH=~/.composer/vendor/bin:$PATH
@@ -67,10 +65,9 @@ before_script:
   - composer require silverstripe/recipe-testing:^1 silverstripe/recipe-core:$RECIPE_VERSION silverstripe/versioned:1.x-dev --no-update
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.x-dev --no-update; fi
   - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.x-dev --no-update; fi
-  - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile; fi
   - if [[ $BEHAT_TEST == cms ]]; then composer require silverstripe/recipe-cms:$RECIPE_VERSION --no-update; fi
 
-  - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
+  - composer update $COMPOSER_ARG --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
   - composer show
 
 # Install NPM dependencies

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,14 @@
     "require": {
         "silverstripe/framework": "^4.5",
         "silverstripe/versioned": "^1@dev",
-        "silverstripe/vendor-plugin": "^1.0"
+        "silverstripe/vendor-plugin": "^1.0",
+        "php": "^7.1 || ^8"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7",
+        "squizlabs/php_codesniffer": "^3",
+        "nikic/php-parser": "^3 || ^4",
+        "monolog/monolog": "~1.16"
     },
     "extra": {
         "expose": [


### PR DESCRIPTION
MNT: Add a prefer-lowest build

In addition, remove the unnecessary duplication in builds, and shift
codesniffer installation to be part of the require-dev deps in keeping
with other repos.