### PR TITLE
Defensive change

### DIFF
--- a/client/src/legacy/ToastsContainer.js
+++ b/client/src/legacy/ToastsContainer.js
@@ -28,6 +28,11 @@ jQuery.entwine('ss', ($) => {
 ((jquery) => {
   jquery.extend({
     noticeAdd(options) {
+      // If reducer is not available, log to the console
+      if(!Injector.reducer) {
+        console.log(options.type + ': ' + options.text);
+        return;
+      }
       // Manually dispatch a redux display event
       const { dispatch } = Injector.reducer.store;
       dispatch(display(options));


### PR DESCRIPTION
I'm not sure why, but on page load, the reducer.store may not be available. This change ensures the page loads regardless of the reducer. i know it's probably not a good idea to log stuff to the console, but i have no idea how to fix the missing reducer

See #1163