### PR TITLE
BUG Update getManagedModelTabs so it can still work with the old output format of getManagedModels

### DIFF
--- a/code/ModelAdmin.php
+++ b/code/ModelAdmin.php
@@ -416,7 +416,9 @@ abstract class ModelAdmin extends LeftAndMain
             $forms->push(new ArrayData(array(
                 'Title' => $options['title'],
                 'Tab' => $tab,
-                'ClassName' => $options['dataClass'],
+                // `getManagedModels` did not always return a `dataClass` attribute
+                // Legacy behaviour is for `ClassName` to map to `$tab`
+                'ClassName' => isset($options['dataClass']) ? $options['dataClass'] : $tab,
                 'Link' => $this->Link($this->sanitiseClassName($tab)),
                 'LinkOrCurrent' => ($tab == $this->modelTab) ? 'current' : 'link'
             )));

--- a/tests/php/ModelAdminTest/MultiModelAdmin.php
+++ b/tests/php/ModelAdminTest/MultiModelAdmin.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SilverStripe\Admin\Tests\ModelAdminTest;
+
+use SilverStripe\Admin\ModelAdmin;
+use SilverStripe\Control\Controller;
+use SilverStripe\Dev\TestOnly;
+
+class MultiModelAdmin extends ModelAdmin implements TestOnly
+{
+    private static $url_segment = 'multi';
+
+    private static $managed_models = [
+        Contact::class,
+        'Player' => [
+            'dataClass' => Player::class,
+            'title' => 'Ice Hockey Players'
+        ],
+        Player::class => [
+            'title' => 'Rugby Players'
+        ]
+    ];
+
+    public function Link($action = null)
+    {
+        if (!$action) {
+            $action = $this->sanitiseClassName($this->modelClass);
+        }
+        return Controller::join_links('ContactAdmin', $action, '/');
+    }
+
+    // The purpose of this method is to increase the visibility of ModelAdmin::getManagedModelTabs()
+    // from protected to public
+    public function getManagedModelTabs()
+    {
+        return parent::getManagedModelTabs();
+    }
+}


### PR DESCRIPTION
https://github.com/silverstripe/silverstripe-admin/pull/1072 updated the output format of `getManagedModels`. If your `ModelAdmin` has overridden `getManagedModels`, it might still be returning the old format which will cause `getManagedModelTabs` to fall flat on its face. e.g.: [RegistryAdmin](https://github.com/silverstripe/silverstripe-registry/blob/2/src/RegistryAdmin.php#L30)

I'm calling this a semver breakage.

# Related
- https://github.com/silverstripe/silverstripe-framework/pull/9837