### PR TITLE
FIX ModelAdmin::$model_importers alias support

### DIFF
--- a/tests/php/ModelAdminTest.php
+++ b/tests/php/ModelAdminTest.php
@@ -2,17 +2,19 @@
 
 namespace SilverStripe\Admin\Tests;
 
-use SilverStripe\Admin\Tests\ModelAdminTest\Contact;
-use SilverStripe\Admin\Tests\ModelAdminTest\Player;
-use SilverStripe\Control\HTTPRequest;
+use SilverStripe\View\ArrayData;
 use SilverStripe\Control\Session;
+use SilverStripe\Dev\CsvBulkLoader;
+use SilverStripe\Dev\FunctionalTest;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Security\Permission;
 use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Admin\Tests\ModelAdminTest\Player;
+use SilverStripe\Admin\Tests\ModelAdminTest\Contact;
+use SilverStripe\Forms\GridField\GridFieldPrintButton;
 use SilverStripe\Forms\GridField\GridFieldExportButton;
 use SilverStripe\Forms\GridField\GridFieldImportButton;
-use SilverStripe\Forms\GridField\GridFieldPrintButton;
-use SilverStripe\Security\Permission;
-use SilverStripe\Dev\FunctionalTest;
-use SilverStripe\View\ArrayData;
+use SilverStripe\Admin\Tests\ModelAdminTest\ModelAdminTestBulkLoader;
 
 class ModelAdminTest extends FunctionalTest
 {
@@ -161,6 +163,45 @@ class ModelAdminTest extends FunctionalTest
              ],
             $models[Player::class],
             'Managed Model without a dataClass provided default to using the class name for dataClass'
+        );
+    }
+
+    public function testGetModelImporters()
+    {
+        $admin = new ModelAdminTest\MultiModelAdmin();
+        $importers = $admin->getModelImporters();
+
+        $this->assertArrayHasKey(
+            Contact::class,
+            $importers,
+            'Implicit models'
+        );
+        $this->assertInstanceOf(
+            CsvBulkLoader::class,
+            $importers[Contact::class],
+            'Implicit models create default bulk loaders'
+        );
+
+        $this->assertArrayHasKey(
+            'Player',
+            $importers,
+            'Explicit models by alias'
+        );
+        $this->assertInstanceOf(
+            ModelAdminTestBulkLoader::class,
+            $importers['Player'],
+            'Explicit models by alias allow custom bulk loaders'
+        );
+
+        $this->assertArrayHasKey(
+            Player::class,
+            $importers,
+            'Explicit models by class'
+        );
+        $this->assertInstanceOf(
+            ModelAdminTestBulkLoader::class,
+            $importers[Player::class],
+            'Explicit models by alias allow custom bulk loaders'
         );
     }
 

--- a/tests/php/ModelAdminTest/ModelAdminTestBulkLoader.php
+++ b/tests/php/ModelAdminTest/ModelAdminTestBulkLoader.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SilverStripe\Admin\Tests\ModelAdminTest;
+
+use SilverStripe\Dev\CsvBulkLoader;
+
+class ModelAdminTestBulkLoader extends CsvBulkLoader
+{
+
+}

--- a/tests/php/ModelAdminTest/MultiModelAdmin.php
+++ b/tests/php/ModelAdminTest/MultiModelAdmin.php
@@ -2,9 +2,10 @@
 
 namespace SilverStripe\Admin\Tests\ModelAdminTest;
 
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\Admin\ModelAdmin;
 use SilverStripe\Control\Controller;
-use SilverStripe\Dev\TestOnly;
+use SilverStripe\Admin\Tests\ModelAdminTest\ModelAdminTestBulkLoader;
 
 class MultiModelAdmin extends ModelAdmin implements TestOnly
 {
@@ -19,6 +20,15 @@ class MultiModelAdmin extends ModelAdmin implements TestOnly
         Player::class => [
             'title' => 'Rugby Players'
         ]
+    ];
+
+    private static $model_importers = [
+        // Implicit for class
+        // Contact::class,
+        // Explicit for alias
+        'Player' => ModelAdminTestBulkLoader::class,
+        // Explicit for class
+        Player::class => ModelAdminTestBulkLoader::class
     ];
 
     public function Link($action = null)


### PR DESCRIPTION
Hasn't been considered when introducing aliases rather than class names
in $managed_models.