### PR TITLE
MNT Ensure graphql 3 versions of behat tests run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,33 @@ jobs:
         - REQUIRE_INSTALLER="$REQUIRE_RECIPE"
         - NPM_TEST=1
         - RELEASE=1
-    - php: 7.2
+    - php: 7.3
       env:
         - DB=MYSQL
         - REQUIRE_INSTALLER="$REQUIRE_RECIPE"
         - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev"
         - BEHAT_SUITE="admin"
     - php: 7.3
       env:
         - DB=MYSQL
         - REQUIRE_INSTALLER="$REQUIRE_RECIPE"
         - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev"
+        - BEHAT_SUITE="cms"
+    - php: 7.3
+      env:
+        - DB=MYSQL
+        - REQUIRE_INSTALLER="$REQUIRE_RECIPE"
+        - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^4@dev"
+        - BEHAT_SUITE="admin"
+    - php: 7.3
+      env:
+        - DB=MYSQL
+        - REQUIRE_INSTALLER="$REQUIRE_RECIPE"
+        - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^4@dev"
         - BEHAT_SUITE="cms"
 
 before_script:


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-admin/issues/1213

Admin is a bit of strange one that runs both 'admin' and 'cms' behat suites.  It's debatable whether things should be this way, though for now I think we should keep it as is.

This PR will ensure that both behat suites have both graphql 3 and graphql 4 jobs run

The new graphql 3 behat tests are passing, though the graphql 4 build has an existing failure
