### PR TITLE
NEW Add dedicated controller to displays errors in CMS

### DIFF
--- a/code/ErrorAdmin.php
+++ b/code/ErrorAdmin.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SilverStripe\Admin;
+
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\View\ArrayData;
+
+class ErrorAdmin extends LeftAndMain
+{
+
+    private static $menu_title = 'Error';
+
+    private static $url_handlers = [
+        '$*' => 'index'
+    ];
+
+    /**
+     * @param HTTPRequest $request
+     * @return HTTPResponse
+     */
+    public function index($request)
+    {
+        return $this->getResponseNegotiator()->respond($request);
+    }
+
+    public function Link($action = null)
+    {
+        $link = AdminRootController::admin_url();
+        $this->extend('updateLink', $link);
+        return $link;
+    }
+    
+}

--- a/templates/SilverStripe/Admin/Includes/ErrorAdmin_EditForm.ss
+++ b/templates/SilverStripe/Admin/Includes/ErrorAdmin_EditForm.ss
@@ -1,0 +1,11 @@
+<div class="toolbar toolbar--north cms-content-header vertical-align-items">
+    <div class="cms-content-header-info flexbox-area-grow vertical-align-items">
+        <% with $Controller %>
+            <% include SilverStripe\\Admin\\CMSBreadcrumbs %>
+        <% end_with %>
+    </div>
+</div>
+
+<div class="panel panel--padded panel--scrollable flexbox-area-grow <% if not $Fields.hasTabset %>cms-panel-padded<% end_if %>">
+    The Page you are looking for cannot be found.
+</div>


### PR DESCRIPTION
This is an experimental project. The idea is that you could display more useful errors when something goes wrong in the CMS