### PR TITLE
BUG Fix broken ModelAdmin test

### DIFF
--- a/tests/php/ModelAdminTest.php
+++ b/tests/php/ModelAdminTest.php
@@ -38,14 +38,33 @@ class ModelAdminTest extends FunctionalTest
         $this->assertEquals(200, $this->get('ContactAdmin')->getStatusCode());
     }
 
+
+
+
     public function testMultiModelAdminOpensEachTab()
     {
         $admin = new MultiModelAdmin();
+        $this->logInWithPermission();
         foreach ($admin->getManagedModelTabs()->toNestedArray() as $tab) {
             $request = new HTTPRequest('GET', $tab['Link']);
             $request->setRouteParams(['ModelClass' => substr($tab['Link'], strlen('admin/multi/'))]);
+            $request->setSession(new Session([]));
             $admin->setRequest($request);
             $admin->doInit();
+            $this->assertEquals(
+                $tab["Tab"],
+                $admin->getModelTab(),
+                sprintf('Accessing the %s link resolves to the %s tab', $tab['Link'], $tab["Tab"])
+            );
+            $this->assertEquals(
+                $tab["ClassName"],
+                $admin->getModelClass(),
+                sprintf(
+                    'Accessing the %s link sets the ModelAdmin class to %s',
+                    $tab['Link'],
+                    $tab["ClassName"]
+                )
+            );
         }
     }
 

--- a/tests/php/ModelAdminTest/MultiModelAdmin.php
+++ b/tests/php/ModelAdminTest/MultiModelAdmin.php
@@ -31,4 +31,16 @@ class MultiModelAdmin extends ModelAdmin implements TestOnly
     {
         return parent::getManagedModelTabs();
     }
+
+    /** Allow public access to protected $modelTab attribute */
+    public function getModelTab()
+    {
+        return $this->modelTab;
+    }
+
+    /** Allow public access to protected $modelClass attribute */
+    public function getModelClass()
+    {
+        return $this->modelClass;
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/silverstripe/silverstripe-admin/issues/1219

The `testMultiModelAdminOpensEachTab` test fails when subsite is installed which fails the sink. Not 100% sure why.

This PR makes the test more resilient by explicitly logging in a user and setting a session.