### PR TITLE
MNT Fix ModelAdminTest to work with sudo mode

### DIFF
--- a/tests/php/ModelAdminTest.php
+++ b/tests/php/ModelAdminTest.php
@@ -7,6 +7,7 @@ use SilverStripe\Admin\Tests\ModelAdminTest\MultiModelAdmin;
 use SilverStripe\Admin\Tests\ModelAdminTest\Player;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Session;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldExportButton;
 use SilverStripe\Forms\GridField\GridFieldImportButton;
@@ -49,6 +50,7 @@ class ModelAdminTest extends FunctionalTest
             $request = new HTTPRequest('GET', $tab['Link']);
             $request->setRouteParams(['ModelClass' => substr($tab['Link'], strlen('admin/multi/'))]);
             $request->setSession(new Session([]));
+            Injector::inst()->registerService($request, HTTPRequest::class);
             $admin->setRequest($request);
             $admin->doInit();
             $this->assertEquals(


### PR DESCRIPTION
This [line on SudoModeController](https://github.com/silverstripe/silverstripe-security-extensions/blob/16448058c285b3eb5b6712902f8f7d9fe7becd31/src/Control/SudoModeController.php#L60) expects the request to be registered in Injector.

This breaks the test when the security extension module is installed.

Fixes https://github.com/silverstripe/silverstripe-admin/issues/1219