### PR TITLE
ENH: Allow use of the preview panel in any LeftAndMain subclass.

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -39,6 +39,7 @@ en:
     MenuToggleAuto: Auto
     MenuToggleStickyNav: 'Sticky nav'
     NavigateUp: 'Navigate up a folder'
+    NO_PREVIEW: 'No preview available'
     PERMAGAIN: 'You have been logged out of the CMS.  If you would like to log in again, enter a username and password below.'
     PERMALREADY: 'I''m sorry, but you can''t access that part of the CMS.  If you want to log in as someone else, do so below.'
     PERMDEFAULT: 'You must be logged in to access the administration area; please enter your credentials below.'

--- a/templates/SilverStripe/Admin/Includes/LeftAndMain_EditForm.ss
+++ b/templates/SilverStripe/Admin/Includes/LeftAndMain_EditForm.ss
@@ -54,6 +54,10 @@
 				<%t SilverStripe\Admin\LeftAndMain.PreviewButton 'Preview' %> &raquo;
 			</a>
 			<% end_if %>
+
+			<% if $hasExtraClass('cms-previewable') %>
+				<% include SilverStripe\\Admin\\LeftAndMain_ViewModeSelector SelectID="preview-mode-dropdown-in-content" %>
+			<% end_if %>
 		</div>
 		<% end_if %>
 	</div>

--- a/templates/SilverStripe/Admin/Includes/LeftAndMain_PreviewPanel.ss
+++ b/templates/SilverStripe/Admin/Includes/LeftAndMain_PreviewPanel.ss
@@ -1,0 +1,16 @@
+<div class="cms-preview fill-height flexbox-area-grow" data-layout-type="border">
+	<div class="panel flexbox-area-grow fill-height">
+		<div class="preview-note">
+            <div class="icon font-icon-monitor display-1"></div>
+            <%t SilverStripe\Admin\LeftAndMain.NO_PREVIEW 'No preview available' %>
+        </div>
+		<div class="preview__device">
+			<div class="preview-device-outer">
+				<div class="preview-device-inner">
+					<iframe src="about:blank" class="center" name="cms-preview-iframe"></iframe>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="toolbar toolbar--south cms-content-controls cms-preview-controls"></div>
+</div>


### PR DESCRIPTION
For some reason, the preview panel template which is referred to in `LeftAndMain::PreviewPanel()` only exists in the cms module for the `CMSMain` controller.

All of the other code for using a CMS preview is available for any arbitrary `LeftAndMain` subclass and is available in this module. There should be no dependency from this module on the cms module to allow previews, and previews should work for all `LeftAndMain` subclasses in this module (e.g. `ModelAdmin`).

Required for #1250

Edit: Depends on silverstripe/silverstripe-framework#10112