### PR TITLE
FIX LeftAndMain_MenuToggle limit to 4 characters rather then 3.

### DIFF
--- a/templates/SilverStripe/Admin/Includes/LeftAndMain_MenuToggle.ss
+++ b/templates/SilverStripe/Admin/Includes/LeftAndMain_MenuToggle.ss
@@ -6,7 +6,7 @@
         </span>
         <span class="cms-help__badge badge badge-info">
                 <% if $CMSVersionNumber %>
-                    <span class="cms-sitename__version" title="$ApplicationName (<%t SilverStripe\Admin\LeftAndMain.Version "Version" %> - $CMSVersion)">$CMSVersionNumber.LimitCharacters(3, '')</span>
+                    <span class="cms-sitename__version" title="$ApplicationName (<%t SilverStripe\Admin\LeftAndMain.Version "Version" %> - $CMSVersion)">$CMSVersionNumber.LimitCharacters(4, '')</span>
                 <% end_if %>
             </span>
             <span class="cms-help__caret font-icon-caret-up-two"></span>


### PR DESCRIPTION
FIX LeftAndMain_MenuToggle limit to 4 characters rather then 3 in order to support 4.xx.

Fixes display of 4.10 as 4.1.