### PR TITLE
ENH: Prefer dependency injection for GridFieldComponents.

### DIFF
--- a/code/ModelAdmin.php
+++ b/code/ModelAdmin.php
@@ -6,6 +6,7 @@ use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Convert;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\BulkLoader;
 use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\CheckboxField;
@@ -245,17 +246,17 @@ abstract class ModelAdmin extends LeftAndMain
     {
         $config = GridFieldConfig_RecordEditor::create($this->config()->get('page_length'));
 
-        $exportButton = new GridFieldExportButton('buttons-before-left');
+        $exportButton = Injector::inst()->createWithArgs(GridFieldExportButton::class, ['buttons-before-left']);
         $exportButton->setExportColumns($this->getExportFields());
 
         $config
             ->addComponent($exportButton)
-            ->addComponents(new GridFieldPrintButton('buttons-before-left'));
+            ->addComponents(Injector::inst()->createWithArgs(GridFieldPrintButton::class, ['buttons-before-left']));
 
         // Remove default and add our own filter header with extension points
         // to retain API until deprecation in 5.0
         $config->removeComponentsByType(GridFieldFilterHeader::class);
-        $config->addComponent(new GridFieldFilterHeader(
+        $config->addComponent(Injector::inst()->createWithArgs(GridFieldFilterHeader::class, [
             false,
             function ($context) {
                 $this->extend('updateSearchContext', $context);
@@ -263,7 +264,7 @@ abstract class ModelAdmin extends LeftAndMain
             function ($form) {
                 $this->extend('updateSearchForm', $form);
             }
-        ));
+        ]));
 
         if (!$this->showSearchForm ||
             (is_array($this->showSearchForm) && !in_array($this->modelClass, $this->showSearchForm))

--- a/code/SecurityAdmin.php
+++ b/code/SecurityAdmin.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Admin;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Convert;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\GridField\GridField;
@@ -94,9 +95,9 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider
     {
         // Build gridfield configs
         $memberListConfig = GridFieldConfig_RecordEditor::create()
-            ->addComponent(new GridFieldExportButton('buttons-before-left'));
+            ->addComponent(Injector::inst()->createWithArgs(GridFieldExportButton::class, ['buttons-before-left']));
         $groupListConfig = GridFieldConfig_RecordEditor::create()
-            ->addComponent(new GridFieldExportButton('buttons-before-left'));
+            ->addComponent(Injector::inst()->createWithArgs(GridFieldExportButton::class, ['buttons-before-left']));
 
         /** @var GridFieldDetailForm $detailForm */
         $detailForm = $memberListConfig->getComponentByType(GridFieldDetailForm::class);
@@ -105,7 +106,7 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider
 
         /** @var GridFieldPageCount $groupPaginator */
         $groupListConfig->removeComponentsByType(GridFieldPageCount::class);
-        $groupListConfig->addComponent(new GridFieldPageCount('buttons-before-right'));
+        $groupListConfig->addComponent(Injector::inst()->createWithArgs(GridFieldPageCount::class, ['buttons-before-right']));
 
         // Add import capabilities. Limit to admin since the import logic can affect assigned permissions
         if (Permission::check('ADMIN')) {


### PR DESCRIPTION
`GridFieldComponent`s packaged with silverstripe/framework will be injectable as of 4.11.0 (see silverstripe/silverstripe-framework#10204)
Explicitly invoking the injector here instead of using `create()` allows backwards compatibility with framework < 4.11.0 while ensuring dependency injection is still used from 4.11.0 onwards.

If core team would prefer, I can instead use the `::create()` static method which was added via the `Injectable` trait - but that will also require updating the constraint for the framework dependency to `^4.11`.