### PR TITLE
MNT Create seperate page for site settings test

### DIFF
--- a/tests/behat/features/site-settings.feature
+++ b/tests/behat/features/site-settings.feature
@@ -4,9 +4,12 @@ Feature: Site settings
 
   Background:
     Given a "page" "Home"
+    And a "page" "MyPage"
     When I am logged in with "ADMIN" permissions
     And I go to "/admin/pages"
     And I follow "Home"
+    And I press the "Publish" button
+    And I follow "MyPage"
     And I press the "Publish" button
     
   Scenario: Change site visibility
@@ -36,5 +39,5 @@ Feature: Site settings
     When I go to "/admin/settings"
     And I fill in "Site title" with "My website"
     And I press the "Save" button
-    When I go to "/home"
+    When I go to "/mypage"
     Then the rendered HTML should contain "My website"


### PR DESCRIPTION
Attempt to fix https://app.travis-ci.com/github/silverstripe/silverstripe-installer/jobs/560491370#L1999 which I cannot replicate locally, though I have a feeling there's an cached error page somewhere not being updated when the site title is updated, so instead of serving an unpublished page, serve a published page