### PR TITLE
BUG Add missing dependency to build pattern library

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "enzyme-adapter-react-16": "^1.5.0",
     "fast-glob": "^3.0.1",
     "html-loader": "^0.5.1",
+    "is-plain-object": "^5.0.0",
     "jest-cli": "^23.6.0",
     "markdown-loader": "^5.1.0",
     "storybook-addon-jsx": "^5.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3074,12 +3074,7 @@ colormin@^1.0.5:
     css-color-names "0.0.4"
     has "^1.0.1"
 
-colors@^1.1.2:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
-  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
-
-colors@~1.1.2:
+colors@1.1.2, colors@^1.1.2, colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
   integrity sha1-FopHAXVran9RoSzgyXv6KMCE7WM=
@@ -6515,7 +6510,7 @@ is-plain-obj@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
-is-plain-object@5.0.0:
+is-plain-object@5.0.0, is-plain-object@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
   integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==


### PR DESCRIPTION
The pattern library is throwing some errors for `isPlainObject.isPlainObject is not a function`. Adding the `is-plain-object` library to admin's dev dependencies fixes it.

![image](https://user-images.githubusercontent.com/1168676/155226718-c69ae1ef-64ad-4602-adfe-895bd35e994d.png)

# Parent issue
- https://github.com/silverstripe/silverstripe-pattern-lib/issues/2
