### PR TITLE
ENH Display error messages in admin with an admin context

### DIFF
--- a/_config/forms.yml
+++ b/_config/forms.yml
@@ -16,3 +16,7 @@ SilverStripe\Forms\Form:
 SilverStripe\Forms\FormField:
   extensions:
   - SilverStripe\Forms\FormMessageBootstrapExtension
+
+SilverStripe\Control\RequestHandler:
+  extensions:
+    - SilverStripe\Admin\AdminErrorExtension

--- a/code/AdminErrorExtension.php
+++ b/code/AdminErrorExtension.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SilverStripe\Admin;
+
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\Director;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Extension;
+
+class AdminErrorExtension extends Extension
+{
+    /**
+     * Used by {@see RequestHandler::httpError}
+     */
+    public function onBeforeHTTPError($statusCode, HTTPRequest $request, $errorMessage = null)
+    {
+        $controller = $this->getAdminController();
+        if (!$controller || Director::is_ajax($request)) {
+            return;
+        }
+        $controller->setHttpErrorMessage($errorMessage);
+    }
+
+    private function getAdminController(): ?Controller
+    {
+        if ($this->owner instanceof LeftAndMain) {
+            return $this->owner;
+        }
+        if (Controller::has_curr() && (Controller::curr() instanceof LeftAndMain)) {
+            return Controller::curr();
+        }
+        return null;
+    }
+}

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -33,6 +33,12 @@ en:
     CollapsePanel: 'Collapse panel'
     DELETED: Deleted.
     DropdownBatchActionsDefault: 'Choose an action...'
+    ErrorDetail: 'Error detail: {detail}'
+    ErrorMessage: 'Sorry, it seems there was a {errorcode} error.'
+    ErrorMessage403: 'Sorry, it seems the action you were trying to perform is forbidden.'
+    ErrorMessage404: 'Sorry, it seems you were trying to access a section or object that doesn''t exist.'
+    ErrorMessage500: 'Sorry, it seems there was an internal server error.'
+    ErrorMessage503: 'Sorry, it seems the service is temporarily unavailable.'
     ExpandPanel: 'Expand panel'
     HelpMenu: 'Help menu'
     LOGOUT: 'Log out'

--- a/templates/SilverStripe/Admin/Includes/LeftAndMain_Error.ss
+++ b/templates/SilverStripe/Admin/Includes/LeftAndMain_Error.ss
@@ -1,0 +1,24 @@
+<div class="cms-content flexbox-area-grow $BaseCSSClasses" data-layout-type="border" data-pjax-fragment="Content">
+
+    <div class="cms-content-header north">
+        <div class="cms-content-header-info vertical-align-items flexbox-area-grow">
+            <div class="breadcrumbs-wrapper">
+                <span class="cms-panel-link crumb last">
+                    $ErrorType
+                </span>
+            </div>
+        </div>
+    </div>
+
+    $Tools
+
+    <div class="panel panel--padded">
+        <p>$Message</p>
+        <% if $isDev && $HttpErrorMessage %>
+            <p>
+                <strong><%t SilverStripe\Admin\LeftAndMain.ErrorDetail "Error detail: {detail}" detail=$HttpErrorMessage %></strong>
+            </p>
+        <% end_if %>
+    </div>
+
+</div>

--- a/tests/behat/features/notfound.feature
+++ b/tests/behat/features/notfound.feature
@@ -1,0 +1,39 @@
+@gsat
+Feature: Not found
+  As a site owner
+  I want error messages to be displayed in the context of the admin section
+
+  Background:
+    Given I am logged in with "ADMIN" permissions
+
+  Scenario: Errors are displayed in the admin context
+    Given I go to "/admin/nothing"
+    Then I should see "Not Found"
+    And I should see "Sorry, it seems you were trying to access a section or object that doesn't exist."
+    And I should see the admin menu
+    Given I go to "/admin/pages/nothing"
+    Then I should see "Not Found"
+    And I should see "Sorry, it seems you were trying to access a section or object that doesn't exist."
+    And I should see the admin menu
+    Given I go to "/admin/security/EditForm/nothing"
+    Then I should see "Not Found"
+    And I should see "Sorry, it seems you were trying to access a section or object that doesn't exist."
+    And I should see the admin menu
+    Given I go to "/admin/security/EditForm/field/Members/nothing"
+    Then I should see "Not Found"
+    And I should see "Sorry, it seems you were trying to access a section or object that doesn't exist."
+    And I should see the admin menu
+    Given I go to "/admin/settings/nothing"
+    Then I should see "Not Found"
+    And I should see "Sorry, it seems you were trying to access a section or object that doesn't exist."
+    And I should see the admin menu
+
+  Scenario: Valid routes do not display the error
+    Given I go to "/admin/settings"
+    Then I should not see "Not Found"
+    And I should not see "Sorry, it seems you were trying to access a section or object that doesn't exist."
+    And I should see the admin menu
+    Given I go to "/admin/security/EditForm/field/Members/item/new"
+    Then I should not see "Not Found"
+    And I should not see "Sorry, it seems you were trying to access a section or object that doesn't exist."
+    And I should see the admin menu

--- a/tests/behat/src/AdminContext.php
+++ b/tests/behat/src/AdminContext.php
@@ -38,6 +38,24 @@ class AdminContext implements Context
     }
 
     /**
+     * @Then /^I should (not |)see the admin menu/
+     * @param string $not
+     * @param string $tabLabel
+     */
+    public function iShouldSeeTheAdminMenu(string $not)
+    {
+        $selector = '#cms-menu';
+        $page = $this->getMainContext()->getSession()->getPage();
+        if ($not) {
+            $element = $page->find('css', $selector);
+            Assert::assertNull($element, 'The admin menu is visible when it should not be');
+        } else {
+            $element = $page->find('css', $selector);
+            Assert::assertNotNull($element, 'The admin menu was not found');
+        }
+    }
+
+    /**
      * @When /^I can (not |)see the form validation error message$/
      * @param $not
      */


### PR DESCRIPTION
Currently if there is an error in any /admin route, there is no admin-specific way of handling the errors.
This means that if silverstripe/errorpage is installed the user is shown the frontend error page (if there is one) and if it isn't installed or doesn't have a page for the given error, a simple text message is displayed.

This PR renders an error message in the context of the admin, so that users can simply select an appropriate section in the left menu.

The error detail only appears in Dev mode. 

**In this example I tried to navigate to /admin/badonk and an appropriate 404 error is displayed**
![image](https://user-images.githubusercontent.com/36352093/177129656-63ff6910-e298-42ef-8178-4bae78e993e5.png)

**In this example I tried to navigate to /admin/pages/save and an appropriate forbidden error is displayed**
![image](https://user-images.githubusercontent.com/36352093/177130272-ae3a5e82-d8d5-4673-a413-18a74ea0b5c8.png)

## Parent issues
- fixes https://github.com/silverstripe/silverstripe-admin/issues/1232
- fixes https://github.com/silverstripe/silverstripe-cms/issues/2669

## Depends on
- https://github.com/silverstripe/silverstripe-errorpage/pull/67