### PR TITLE
MNT Require frameworktest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
+        "silverstripe/frameworktest": "^0.4.3",
         "squizlabs/php_codesniffer": "^3",
         "nikic/php-parser": "^3 || ^4",
         "monolog/monolog": "~1.16"


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

Fix failing behat tests https://github.com/silverstripe/silverstripe-admin/runs/7490775317?check_suite_focus=true#step:12:715

silverstripe/frameworktest ^0.4.3 is included in 1.10 composer require-dev and is also in .travis.yml


