### PR TITLE
FIX Don't try to use a property that isn't initialised.

### DIFF
--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -780,7 +780,7 @@ class LeftAndMain extends Controller implements PermissionProvider
 
     public function afterHandleRequest()
     {
-        if ($this->response->isError()) {
+        if ($this->response->isError() && !$this->request->isAjax()) {
             $this->init();
             $errorCode = $this->response->getStatusCode();
             $errorType = $this->response->getStatusDescription();
@@ -2035,7 +2035,7 @@ class LeftAndMain extends Controller implements PermissionProvider
      */
     public function getHttpErrorMessage(): string
     {
-        return $this->httpErrorMessage;
+        return $this->httpErrorMessage ?? '';
     }
 
     /**


### PR DESCRIPTION
Errors happen if php tries to get the value from an uninitailised property, which is causing tests to fail:
https://github.com/silverstripe/silverstripe-cms/runs/7571102762?check_suite_focus=true
> 1) SilverStripe\CMS\Tests\Controllers\CMSMainTest::testCreationOfTopLevelPage
Error: Typed property SilverStripe\Admin\LeftAndMain::$httpErrorMessage must not be accessed before initialization

The new error handling logic should also not apply to AJAX requests, which are likely to format their own errors e.g. in JSON