### PR TITLE
FIX Don't overwrite JSON errors with templated error page

### DIFF
--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -780,7 +780,10 @@ class LeftAndMain extends Controller implements PermissionProvider
 
     public function afterHandleRequest()
     {
-        if ($this->response->isError() && !$this->request->isAjax()) {
+        if ($this->response->isError()
+            && !$this->request->isAjax()
+            && $this->response->getHeader('Content-Type') !== 'application/json'
+        ) {
             $this->init();
             $errorCode = $this->response->getStatusCode();
             $errorType = $this->response->getStatusDescription();

--- a/tests/behat/features/notfound.feature
+++ b/tests/behat/features/notfound.feature
@@ -1,4 +1,3 @@
-@gsat
 Feature: Not found
   As a site owner
   I want error messages to be displayed in the context of the admin section


### PR DESCRIPTION
The new error handling logic was overwriting JSON error messages, which are most likely responses for AJAX requests. A more complete fix would be to find out why they weren't being detected as AJAX requests and resolve that - but that could lead to even more regressions, and would be time consuming besides.

## Parent issue
- https://github.com/silverstripe/silverstripe-admin/issues/1332