### PR TITLE
FIX Don't pass null as LeftAndMain error message.

### DIFF
--- a/code/AdminErrorExtension.php
+++ b/code/AdminErrorExtension.php
@@ -15,7 +15,7 @@ class AdminErrorExtension extends Extension
     public function onBeforeHTTPError($statusCode, HTTPRequest $request, $errorMessage = null)
     {
         $controller = $this->getAdminController();
-        if (!$controller || Director::is_ajax($request)) {
+        if (!$controller || Director::is_ajax($request) || $errorMessage === null) {
             return;
         }
         $controller->setHttpErrorMessage($errorMessage);


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-security-extensions/runs/7602515088?check_suite_focus=true
> SilverStripe\SecurityExtensions\Tests\Control\SudoModeControllerTest::testActivateFailsWithGetRequest
TypeError: SilverStripe\Admin\LeftAndMain::setHttpErrorMessage(): Argument `#1` ($message) must be of type string, null given, called in /home/runner/work/silverstripe-security-extensions/silverstripe-security-extensions/vendor/silverstripe/admin/code/AdminErrorExtension.php on line 21

We shouldn't be trying to pass null where we've declared it should be a string.
We have to accept null into this hook anyway as sometimes that's actually passed in - so it still makes sense for that to be the default here. But we shouldn't pass it through.