### PR TITLE
MNT Fix behat tests - explicitly use the advanced filter input

### DIFF
--- a/tests/behat/features/gridfield-search.feature
+++ b/tests/behat/features/gridfield-search.feature
@@ -9,7 +9,7 @@ Feature: Search in GridField
     And the "Employee" "Bill" with "Company"="1"
     And the "Employee" "Ford" with "Company"="1"
     And the "Company" "ExxonMobil" with "Category"="Oil"
-    And the "Company" "Vitol" with "Category"="Other" 
+    And the "Company" "Vitol" with "Category"="Other"
     And I am logged in with "ADMIN" permissions
     And I go to "/admin/test"
 
@@ -17,8 +17,8 @@ Feature: Search in GridField
     When I press the "Open search and filter" button
       And I press the "Advanced" button
     Then I should see a "#Form_CompaniesSearchForm_Search_Name.no-change-track" element
-      And I fill in "SearchBox__Name" with "Walmart"
-      And I press the "Enter" key in the "SearchBox__Name" field
+      And I fill in "Search__Name" with "Walmart"
+      And I press the "Enter" key in the "Search__Name" field
     Then I should see "Walmart" in the "#Form_EditForm" element
       But I should not see "ExxonMobil" in the ".col-Name" element
       And I should not see "Vitol" in the ".col-Name" element

--- a/tests/behat/features/manage-users.feature
+++ b/tests/behat/features/manage-users.feature
@@ -38,8 +38,9 @@ Feature: Manage users
   Scenario: I can search for an existing user by name
     When I click the "Users" CMS tab
     And I press the "Open search and filter" button
-    And I fill in "SearchBox__FirstName" with "ADMIN"
-    And I press the "Enter" key in the "SearchBox__FirstName" field
+    And I press the "Advanced" button
+    And I fill in "Search__FirstName" with "ADMIN"
+    And I press the "Enter" key in the "Search__FirstName" field
     Then I should see "admin@example.org" in the "#Root_Users" element
     But I should not see "staffmember@example.org" in the "#Root_Users" element
     # Required to avoid "unsaved changes" browser dialog


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-admin/runs/7602647956?check_suite_focus=true

> Form field with id|name|label|value "SearchBox__FirstName" not found. (Behat\Mink\Exception\ElementNotFoundException)

> Form field with id|name|label|value "SearchBox__Name" not found. (Behat\Mink\Exception\ElementNotFoundException)

`SearchBox__` is the prefix for the general search field. `Search__` is the prefix for the advanced filter input fields. These tests have been using the wrong field this whole time.
This has come up because the general search field name is now `q` (so `SearchBox__q`)