### PR TITLE
API Migrate SilverStripeNagivator

### DIFF
--- a/code/Forms/GridFieldDetailFormPreviewExtension.php
+++ b/code/Forms/GridFieldDetailFormPreviewExtension.php
@@ -3,7 +3,7 @@
 namespace SilverStripe\Admin\Forms;
 
 use SilverStripe\Admin\LeftAndMain;
-use SilverStripe\CMS\Controllers\SilverStripeNavigator;
+use SilverStripe\Admin\Navigator\SilverStripeNavigator;
 use SilverStripe\Core\Extension;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\LiteralField;

--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -7,7 +7,7 @@ use InvalidArgumentException;
 use LogicException;
 use ReflectionClass;
 use SilverStripe\CMS\Controllers\CMSMain;
-use SilverStripe\CMS\Controllers\SilverStripeNavigator;
+use SilverStripe\Admin\Navigator\SilverStripeNavigator;
 use SilverStripe\Control\ContentNegotiator;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;

--- a/code/Navigator/SilverStripeNavigator.php
+++ b/code/Navigator/SilverStripeNavigator.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace SilverStripe\Admin\Navigator;
+
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\CMSPreviewable;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\SS_List;
+use SilverStripe\View\ViewableData;
+
+/**
+ * Utility class representing links to different views of a record
+ * for CMS authors, usually for {@link SiteTree} objects with "stage" and "live" links.
+ * Useful both in the CMS and alongside the page template (for logged in authors).
+ * The class can be used for any {@link DataObject} subclass implementing the {@link CMSPreviewable} interface.
+ *
+ * New item types can be defined by extending the {@link SilverStripeNavigatorItem} class,
+ * for example the "cmsworkflow" module defines a new "future state" item with a date selector
+ * to view embargoed data at a future point in time. So the item doesn't always have to be a simple link.
+ */
+class SilverStripeNavigator extends ViewableData
+{
+
+    /**
+     * @var DataObject|CMSPreviewable
+     */
+    protected $record;
+
+    /**
+     * @param DataObject|CMSPreviewable $record
+     */
+    public function __construct(CMSPreviewable $record)
+    {
+        parent::__construct();
+        $this->record = $record;
+    }
+
+    /**
+     * @return SS_List of SilverStripeNavigatorItem
+     */
+    public function getItems()
+    {
+        $items = [];
+
+        $classes = ClassInfo::subclassesFor(SilverStripeNavigatorItem::class);
+        array_shift($classes);
+
+        // Sort menu items according to priority
+        foreach ($classes as $class) {
+            /** @var SilverStripeNavigatorItem $item */
+            $item = new $class($this->record);
+            if (!$item->canView()) {
+                continue;
+            }
+
+            // This funny litle formula ensures that the first item added with the same priority will be left-most.
+            $priority = $item->getPriority() * 100 - 1;
+
+            // Ensure that we can have duplicates with the same (default) priority
+            while (isset($items[$priority])) {
+                $priority++;
+            }
+
+            $items[$priority] = $item;
+        }
+        ksort($items);
+
+        // Drop the keys and let the ArrayList handle the numbering, so $First, $Last and others work properly.
+        return new ArrayList(array_values($items ?? []));
+    }
+
+    /**
+     * @return DataObject|CMSPreviewable
+     */
+    public function getRecord()
+    {
+        return $this->record;
+    }
+
+    /**
+     * @param DataObject|CMSPreviewable $record
+     * @return array template data
+     */
+    public static function get_for_record($record)
+    {
+        $html = '';
+        $message = '';
+        $SilverStripeNavigator = new SilverStripeNavigator($record);
+        $items = $SilverStripeNavigator->getItems();
+        foreach ($items as $item) {
+            $text = $item->getHTML();
+            if ($text) {
+                $html .= $text;
+            }
+            $newMessage = $item->getMessage();
+            if ($newMessage && $item->isActive()) {
+                $message = $newMessage;
+            }
+        }
+
+        return [
+            'items' => $html,
+            'message' => $message
+        ];
+    }
+}

--- a/code/Navigator/SilverStripeNavigatorItem.php
+++ b/code/Navigator/SilverStripeNavigatorItem.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace SilverStripe\Admin\Navigator;
+
+use SilverStripe\ORM\CMSPreviewable;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+use SilverStripe\Security\Member;
+use SilverStripe\View\ViewableData;
+
+/**
+ * SilverStripeNavigator items are links that appear in the $SilverStripeNavigator bar.
+ * To add an item, extend this class - it will be automatically picked up.
+ * When instanciating items manually, please ensure to call {@link canView()}.
+ */
+abstract class SilverStripeNavigatorItem extends ViewableData
+{
+    /**
+     * @param DataObject|CMSPreviewable
+     */
+    protected $record;
+
+    /** @var string */
+    protected $recordLink;
+
+    /**
+     * @param DataObject|CMSPreviewable $record
+     */
+    public function __construct(CMSPreviewable $record)
+    {
+        parent::__construct();
+        $this->record = $record;
+    }
+
+    /**
+     * @return string HTML, mostly a link - but can be more complex as well.
+     * For example, a "future state" item might show a date selector.
+     */
+    abstract public function getHTML();
+
+    /**
+     * @return string
+     * Get the Title of an item
+     */
+    abstract public function getTitle();
+
+    /**
+     * Machine-friendly name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return substr(static::class, strpos(static::class, '_') + 1);
+    }
+
+    /**
+     * Optional link to a specific view of this record.
+     * Not all items are simple links, please use {@link getHTML()}
+     * to represent an item in markup unless you know what you're doing.
+     *
+     * @return string
+     */
+    public function getLink()
+    {
+        return null;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMessage()
+    {
+        return null;
+    }
+
+    /**
+     * @return DataObject
+     */
+    public function getRecord()
+    {
+        return $this->record;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPriority()
+    {
+        return $this->config()->get('priority');
+    }
+
+    /**
+     * As items might convey different record states like a "stage" or "live" table,
+     * an item can be active (showing the record in this state).
+     *
+     * @return boolean
+     */
+    public function isActive()
+    {
+        return false;
+    }
+
+    /**
+     * Filters items based on member permissions or other criteria,
+     * such as if a state is generally available for the current record.
+     *
+     * @param Member $member
+     * @return Boolean
+     */
+    public function canView($member = null)
+    {
+        return true;
+    }
+
+    /**
+     * Counts as "archived" if the current record is a different version from both live and draft.
+     *
+     * @return boolean
+     */
+    public function isArchived()
+    {
+        /** @var Versioned|DataObject $record */
+        $record = $this->record;
+        if (!$record->hasExtension(Versioned::class) || !$record->hasStages()) {
+            return false;
+        }
+
+        if (!isset($record->_cached_isArchived)) {
+            $record->_cached_isArchived = $record->isArchived();
+        }
+
+        return $record->_cached_isArchived;
+    }
+}

--- a/code/Navigator/SilverStripeNavigatorItem_Unversioned.php
+++ b/code/Navigator/SilverStripeNavigatorItem_Unversioned.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace SilverStripe\Admin\Navigator;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Convert;
+use SilverStripe\Security\Member;
+use SilverStripe\Versioned\Versioned;
+
+class SilverStripeNavigatorItem_Unversioned extends SilverStripeNavigatorItem
+{
+    public function getHTML()
+    {
+        $recordLink = Convert::raw2att($this->getLink());
+        $linkTitle = _t(__CLASS__ . '.PREVIEW', 'Preview');
+        return "<a class=\"current\" href=\"$recordLink\">$linkTitle</a>";
+    }
+
+    public function getLink()
+    {
+        return $this->getRecord()->PreviewLink() ?? '';
+    }
+
+    public function getTitle()
+    {
+        return  _t(
+            __CLASS__ . '.PREVIEW',
+            'Preview',
+            'Used for the Switch between states (if any other other states are added). Needs to be a short label'
+        );
+    }
+
+    /**
+     * True if the record doesn't have the Versioned extension and is configured to display this item.
+     *
+     * @param Member $member
+     * @return bool
+     */
+    public function canView($member = null)
+    {
+        return (
+            $this->recordIsUnversioned()
+            && $this->showUnversionedLink()
+            && $this->getLink()
+        );
+    }
+
+    private function recordIsUnversioned(): bool
+    {
+        $record = $this->getRecord();
+        // If the record has the Versioned extension, it can be considered unversioned
+        // for the purposes of this class if it has no stages and is not archived.
+        if ($record->hasExtension(Versioned::class)) {
+            return (!$record->hasStages()) && !$this->isArchived();
+        }
+        // Completely unversioned.
+        return true;
+    }
+
+    /**
+     * True if the record is configured to display this item.
+     *
+     * @return bool
+     */
+    public function showUnversionedLink(): bool
+    {
+        return (bool) Config::inst()->get(get_class($this->record), 'show_unversioned_preview_link');
+    }
+
+    /**
+     * This item is always active, as there are unlikely to be other preview states available for the record.
+     *
+     * @return bool
+     */
+    public function isActive()
+    {
+        return true;
+    }
+}

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -95,6 +95,10 @@ en:
     NOIMPORT: 'Nothing to import'
     Title: 'Data Models'
     UPDATEDRECORDS: 'Updated {count} records.'
+  SilverStripe\Admin\Navigator\SilverStripeNavigatorItem:
+    WONT_BE_SHOWN: 'Note: this message will not be shown to your visitors'
+  SilverStripe\Admin\Navigator\SilverStripeNavigatorItem_Unversioned:
+    PREVIEW': 'Preview'
   SilverStripe\Admin\SecurityAdmin:
     ACCESS_HELP: 'Allow viewing, adding and editing users, as well as assigning permissions and roles to them.'
     APPLY_ROLES: 'Apply roles to groups'

--- a/tests/php/Navigator/SilverStripeNavigatorTest.php
+++ b/tests/php/Navigator/SilverStripeNavigatorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace SilverStripe\Admin\Tests\Navigator;
+
+use SilverStripe\Admin\Navigator\SilverStripeNavigator;
+use SilverStripe\Admin\Navigator\SilverStripeNavigatorItem_Unversioned;
+use SilverStripe\Dev\SapphireTest;
+
+class SilverStripeNavigatorTest extends SapphireTest
+{
+    protected static $extra_dataobjects = [
+        UnversionedRecord::class,
+    ];
+
+    public function testGetItemsAutoDiscovery(): void
+    {
+        $record = new UnversionedRecord();
+        $record->PreviewLinkTestProperty = 'some-value';
+        $record->write();
+        $navigator = new SilverStripeNavigator($record);
+        $classes = array_map('get_class', $navigator->getItems()->toArray());
+
+        $this->assertContains(
+            SilverStripeNavigatorTest_TestItem::class,
+            $classes,
+            'Autodiscovers new classes'
+        );
+    }
+
+    public function testGetItemsUnversioned(): void
+    {
+        $record = new UnversionedRecord();
+        $record->previewLinkTestProperty = 'some-value';
+        $record->write();
+        $navigator = new SilverStripeNavigator($record);
+        $classes = array_map('get_class', $navigator->getItems()->toArray());
+
+        // Has the unversioned link
+        $this->assertContains(SilverStripeNavigatorItem_Unversioned::class, $classes);
+    }
+
+    public function testCanViewUnversioned(): void
+    {
+        $record = new UnversionedRecord();
+        $record->write();
+        $unversionedLinkItem = new SilverStripeNavigatorItem_Unversioned($record);
+
+        // Cannot view unversioned link when there's no preview link
+        $this->assertFalse($unversionedLinkItem->canView());
+
+        $record->previewLinkTestProperty = 'some-value';
+
+        // Can view unversioned link
+        $this->assertTrue($unversionedLinkItem->canView());
+    }
+}

--- a/tests/php/Navigator/SilverStripeNavigatorTest_TestItem.php
+++ b/tests/php/Navigator/SilverStripeNavigatorTest_TestItem.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SilverStripe\Admin\Tests\Navigator;
+
+use SilverStripe\Admin\Navigator\SilverStripeNavigatorItem;
+use SilverStripe\Dev\TestOnly;
+
+class SilverStripeNavigatorTest_TestItem extends SilverStripeNavigatorItem implements TestOnly
+{
+    public function getTitle()
+    {
+        return self::class;
+    }
+
+    public function getHTML()
+    {
+        return null;
+    }
+}

--- a/tests/php/Navigator/UnversionedRecord.php
+++ b/tests/php/Navigator/UnversionedRecord.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SilverStripe\Admin\Tests\Navigator;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\CMSPreviewable;
+use SilverStripe\ORM\DataObject;
+
+class UnversionedRecord extends DataObject implements TestOnly, CMSPreviewable
+{
+    private static $table_name = 'SilverStripeNavigatorTest_Unversioned_Record';
+
+    private static $show_stage_link = true;
+
+    private static $show_live_link = true;
+
+    private static $show_unversioned_preview_link = true;
+
+    public $previewLinkTestProperty = null;
+
+    public function PreviewLink($action = null)
+    {
+        return $this->previewLinkTestProperty;
+    }
+
+    public function getMimeType()
+    {
+        return 'text/html';
+    }
+
+    public function CMSEditLink()
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
These classes are useful with `silverstripe/admin` without needing `silverstripe/cms`.

## Parent issue
- https://github.com/silverstripe/silverstripe-admin/issues/1339
