### PR TITLE
ENH Use short array syntax

### DIFF
--- a/code/AdminRootController.php
+++ b/code/AdminRootController.php
@@ -69,11 +69,11 @@ class AdminRootController extends Controller implements TemplateGlobalProvider
     public static function rules()
     {
         if (self::$adminRules === null) {
-            self::$adminRules = array();
+            self::$adminRules = [];
 
             // Map over the array calling add_rule_for_controller on each
             $classes = CMSMenu::get_cms_classes(null, true, CMSMenu::URL_PRIORITY);
-            array_map(array(__CLASS__, 'add_rule_for_controller'), $classes ?? []);
+            array_map([__CLASS__, 'add_rule_for_controller'], $classes ?? []);
         }
         return self::$adminRules;
     }
@@ -135,8 +135,8 @@ class AdminRootController extends Controller implements TemplateGlobalProvider
      */
     public static function get_template_global_variables()
     {
-        return array(
+        return [
             'adminURL' => 'admin_url'
-        );
+        ];
     }
 }

--- a/code/CMSBatchAction.php
+++ b/code/CMSBatchAction.php
@@ -99,14 +99,14 @@ abstract class CMSBatchAction
      *     }
      *  }
      */
-    public function batchaction(SS_List $objs, $helperMethod, $successMessage, $arguments = array())
+    public function batchaction(SS_List $objs, $helperMethod, $successMessage, $arguments = [])
     {
-        $status = array('modified' => array(), 'error' => array(), 'deleted' => array(), 'success' => array());
+        $status = ['modified' => [], 'error' => [], 'deleted' => [], 'success' => []];
 
         foreach ($objs as $obj) {
             // Perform the action
             $id = $obj->ID;
-            if (!call_user_func_array(array($obj, $helperMethod), $arguments ?? [])) {
+            if (!call_user_func_array([$obj, $helperMethod], $arguments ?? [])) {
                 $status['error'][$id] = $id;
             } else {
                 $status['success'][$id] = $id;
@@ -115,9 +115,9 @@ abstract class CMSBatchAction
             // Now make sure the tree title is appropriately updated
             $publishedRecord = DataObject::get_by_id($this->managedClass, $id);
             if ($publishedRecord) {
-                $status['modified'][$id] = array(
+                $status['modified'][$id] = [
                     'TreeTitle' => $publishedRecord->TreeTitle,
-                );
+                ];
             } else {
                 $status['deleted'][$id] = $id;
             }
@@ -148,7 +148,7 @@ abstract class CMSBatchAction
             user_error("Bad \$methodName passed to applicablePagesHelper()", E_USER_WARNING);
         }
 
-        $applicableIDs = array();
+        $applicableIDs = [];
 
         $managedClass = $this->managedClass;
         $draftPages = DataObject::get($managedClass)->byIDs($ids);

--- a/code/CMSBatchActionHandler.php
+++ b/code/CMSBatchActionHandler.php
@@ -25,7 +25,7 @@ class CMSBatchActionHandler extends RequestHandler
 {
 
     /** @config */
-    private static $batch_actions = array();
+    private static $batch_actions = [];
 
     /**
      * List of registered actions
@@ -34,17 +34,17 @@ class CMSBatchActionHandler extends RequestHandler
      */
     private static $registered_actions = null;
 
-    private static $url_handlers = array(
+    private static $url_handlers = [
         '$BatchAction/applicablepages' => 'handleApplicablePages',
         '$BatchAction/confirmation' => 'handleConfirmation',
         '$BatchAction' => 'handleBatchAction',
-    );
+    ];
 
-    private static $allowed_actions = array(
+    private static $allowed_actions = [
         'handleBatchAction',
         'handleApplicablePages',
         'handleConfirmation',
-    );
+    ];
 
     /**
      * @var Controller
@@ -178,7 +178,7 @@ class CMSBatchActionHandler extends RequestHandler
         if ($ids) {
             $applicableIDs = $actionHandler->applicablePages($ids);
         } else {
-            $applicableIDs = array();
+            $applicableIDs = [];
         }
 
         $response = new HTTPResponse(json_encode($applicableIDs));
@@ -206,7 +206,7 @@ class CMSBatchActionHandler extends RequestHandler
         if ($actionHandler->hasMethod('confirmationDialog')) {
             $response = new HTTPResponse(json_encode($actionHandler->confirmationDialog($ids)));
         } else {
-            $response = new HTTPResponse(json_encode(array('alert' => false)));
+            $response = new HTTPResponse(json_encode(['alert' => false]));
         }
 
         $response->addHeader("Content-type", "application/json");
@@ -246,10 +246,10 @@ class CMSBatchActionHandler extends RequestHandler
         foreach ($actions as $urlSegment => $action) {
             $actionObj = $this->buildAction($action['class']);
             if ($actionObj->canView()) {
-                $actionDef = new ArrayData(array(
+                $actionDef = new ArrayData([
                     "Link" => Controller::join_links($this->Link(), $urlSegment),
                     "Title" => $actionObj->getActionTitle(),
-                ));
+                ]);
                 $actionList->push($actionDef);
             }
         }

--- a/code/CMSMenu.php
+++ b/code/CMSMenu.php
@@ -48,7 +48,7 @@ class CMSMenu implements IteratorAggregate, i18nEntityProvider
      *  - array('type' => 'add', 'item' => CMSMenuItem::create(...) )
      *  - array('type' => 'remove', 'code' => 'codename' )
      */
-    protected static $menu_item_changes = array();
+    protected static $menu_item_changes = [];
 
     /**
      * Set to true if clear_menu() is called, to indicate that the default menu shouldn't be
@@ -200,7 +200,7 @@ class CMSMenu implements IteratorAggregate, i18nEntityProvider
      */
     public static function get_menu_items()
     {
-        $menuItems = array();
+        $menuItems = [];
 
         // Set up default menu items
         if (!self::$menu_is_cleared) {
@@ -231,8 +231,8 @@ class CMSMenu implements IteratorAggregate, i18nEntityProvider
         }
 
         // Sort menu items according to priority, then title asc
-        $menuPriority = array();
-        $menuTitle    = array();
+        $menuPriority = [];
+        $menuTitle    = [];
         foreach ($menuItems as $key => $menuItem) {
             $menuPriority[$key] = is_numeric($menuItem->priority) ? $menuItem->priority : 0;
             $menuTitle[$key]    = $menuItem->title;
@@ -255,7 +255,7 @@ class CMSMenu implements IteratorAggregate, i18nEntityProvider
             $member = Security::getCurrentUser();
         }
 
-        $viewableMenuItems = array();
+        $viewableMenuItems = [];
         $allMenuItems = self::get_menu_items();
         if ($allMenuItems) {
             foreach ($allMenuItems as $code => $menuItem) {
@@ -287,7 +287,7 @@ class CMSMenu implements IteratorAggregate, i18nEntityProvider
      */
     public static function remove_menu_item($code)
     {
-        self::$menu_item_changes[] = array('type' => 'remove', 'code' => $code);
+        self::$menu_item_changes[] = ['type' => 'remove', 'code' => $code];
     }
 
     /**
@@ -306,7 +306,7 @@ class CMSMenu implements IteratorAggregate, i18nEntityProvider
      */
     public static function clear_menu()
     {
-        self::$menu_item_changes = array();
+        self::$menu_item_changes = [];
         self::$menu_is_cleared = true;
     }
 
@@ -342,11 +342,11 @@ class CMSMenu implements IteratorAggregate, i18nEntityProvider
             $item->setAttributes($attributes);
         }
 
-        self::$menu_item_changes[] = array(
+        self::$menu_item_changes[] = [
             'type' => 'add',
             'code' => $code,
             'item' => $item,
-        );
+        ];
     }
 
     /**
@@ -357,11 +357,11 @@ class CMSMenu implements IteratorAggregate, i18nEntityProvider
      */
     protected static function add_menu_item_obj($code, $cmsMenuItem)
     {
-        self::$menu_item_changes[] = array(
+        self::$menu_item_changes[] = [
             'type' => 'add',
             'code' => $code,
             'item' => $cmsMenuItem,
-        );
+        ];
     }
 
     /**
@@ -428,7 +428,7 @@ class CMSMenu implements IteratorAggregate, i18nEntityProvider
     public function provideI18nEntities()
     {
         $cmsClasses = self::get_cms_classes();
-        $entities = array();
+        $entities = [];
         foreach ($cmsClasses as $cmsClass) {
             $defaultTitle = LeftAndMain::menu_title($cmsClass, false);
             $ownerModule = ClassLoader::inst()->getManifest()->getOwnerModule($cmsClass);

--- a/code/CMSMenuItem.php
+++ b/code/CMSMenuItem.php
@@ -49,7 +49,7 @@ class CMSMenuItem
      *
      * @var string
      */
-    protected $attributes = array();
+    protected $attributes = [];
 
     /**
      * @var string
@@ -105,7 +105,7 @@ class CMSMenuItem
         }
 
         // Create markkup
-        $parts = array();
+        $parts = [];
 
         foreach ($attrs as $name => $value) {
             if ($value === true) {

--- a/code/CMSProfileController.php
+++ b/code/CMSProfileController.php
@@ -111,6 +111,6 @@ class CMSProfileController extends LeftAndMain
     public function Breadcrumbs($unlinked = false)
     {
         $items = parent::Breadcrumbs($unlinked);
-        return new ArrayList(array($items[0]));
+        return new ArrayList([$items[0]]);
     }
 }

--- a/code/Forms/UsedOnTable.php
+++ b/code/Forms/UsedOnTable.php
@@ -186,12 +186,12 @@ class UsedOnTable extends FormField
      */
     public function getAttributes()
     {
-        $attributes = array(
+        $attributes = [
             'class' => $this->extraClass(),
             'id' => $this->ID(),
             'data-schema' => json_encode($this->getSchemaData()),
             'data-state' => json_encode($this->getSchemaState()),
-        );
+        ];
 
         $attributes = array_merge($attributes, $this->attributes);
 

--- a/code/GroupImportForm.php
+++ b/code/GroupImportForm.php
@@ -50,7 +50,7 @@ class GroupImportForm extends Form
                 . 'cleared.</li>'
                 . '</ul>'
                 . '</div>',
-                array('columns' => $columns)
+                ['columns' => $columns]
             );
 
             $fields = new FieldList(
@@ -63,7 +63,7 @@ class GroupImportForm extends Form
                     ))
                 )
             );
-            $fileField->getValidator()->setAllowedExtensions(array('csv'));
+            $fileField->getValidator()->setAllowedExtensions(['csv']);
         }
 
         if (!$actions) {
@@ -90,26 +90,26 @@ class GroupImportForm extends Form
         $result = $loader->load($data['CsvFile']['tmp_name']);
 
         // result message
-        $msgArr = array();
+        $msgArr = [];
         if ($result->CreatedCount()) {
             $msgArr[] = _t(
                 __CLASS__ . '.ResultCreated',
                 'Created {count} groups',
-                array('count' => $result->CreatedCount())
+                ['count' => $result->CreatedCount()]
             );
         }
         if ($result->UpdatedCount()) {
             $msgArr[] = _t(
                 __CLASS__ . '.ResultUpdated',
                 'Updated {count} groups',
-                array('count' => $result->UpdatedCount())
+                ['count' => $result->UpdatedCount()]
             );
         }
         if ($result->DeletedCount()) {
             $msgArr[] = _t(
                 __CLASS__ . '.ResultDeleted',
                 'Deleted {count} groups',
-                array('count' => $result->DeletedCount())
+                ['count' => $result->DeletedCount()]
             );
         }
         $msg = ($msgArr) ? implode(',', $msgArr) : _t('SilverStripe\\Admin\\MemberImportForm.ResultNone', 'No changes');

--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -231,7 +231,7 @@ class LeftAndMain extends Controller implements PermissionProvider
      * @config
      * @var array
      */
-    private static $extra_requirements_javascript = array();
+    private static $extra_requirements_javascript = [];
 
     /**
      * YAML configuration example:
@@ -245,13 +245,13 @@ class LeftAndMain extends Controller implements PermissionProvider
      * @config
      * @var array See {@link extra_requirements_javascript}
      */
-    private static $extra_requirements_css = array();
+    private static $extra_requirements_css = [];
 
     /**
      * @config
      * @var array See {@link extra_requirements_javascript}
      */
-    private static $extra_requirements_themedCss = array();
+    private static $extra_requirements_themedCss = [];
 
     /**
      * If true, call a keepalive ping every 5 minutes from the CMS interface,
@@ -642,7 +642,7 @@ class LeftAndMain extends Controller implements PermissionProvider
             }
 
             // if no alternate menu items have matched, return a permission error
-            $messageSet = array(
+            $messageSet = [
                 'default' => _t(
                     __CLASS__ . '.PERMDEFAULT',
                     "You must be logged in to access the administration area; please enter your credentials below."
@@ -657,7 +657,7 @@ class LeftAndMain extends Controller implements PermissionProvider
                     "You have been logged out of the CMS.  If you would like to log in again, enter a username and"
                     . " password below."
                 ),
-            );
+            ];
 
             Security::permissionFailure($this, $messageSet);
             return;
@@ -716,7 +716,7 @@ class LeftAndMain extends Controller implements PermissionProvider
             foreach ($extraJs as $file => $config) {
                 if (is_numeric($file)) {
                     $file = $config;
-                    $config = array();
+                    $config = [];
                 }
 
                 Requirements::javascript($file, $config);
@@ -729,7 +729,7 @@ class LeftAndMain extends Controller implements PermissionProvider
             foreach ($extraCss as $file => $config) {
                 if (is_numeric($file)) {
                     $file = $config;
-                    $config = array();
+                    $config = [];
                 }
                 $media = null;
                 if (isset($config['media'])) {
@@ -747,7 +747,7 @@ class LeftAndMain extends Controller implements PermissionProvider
             foreach ($extraThemedCss as $file => $config) {
                 if (is_numeric($file)) {
                     $file = $config;
-                    $config = array();
+                    $config = [];
                 }
                 $media = null;
                 if (isset($config['media'])) {
@@ -1024,7 +1024,7 @@ class LeftAndMain extends Controller implements PermissionProvider
     {
         if (!$this->responseNegotiator) {
             $this->responseNegotiator = new PjaxResponseNegotiator(
-                array(
+                [
                     'CurrentForm' => function () {
                         return $this->getEditForm()->forTemplate();
                     },
@@ -1040,7 +1040,7 @@ class LeftAndMain extends Controller implements PermissionProvider
                     'default' => function () {
                         return $this->renderWith($this->getViewer('show'));
                     }
-                ),
+                ],
                 $this->getResponse()
             );
         }
@@ -1129,7 +1129,7 @@ class LeftAndMain extends Controller implements PermissionProvider
                         $iconClass = $menuItem->iconClass;
                     }
 
-                    $menu->push(new ArrayData(array(
+                    $menu->push(new ArrayData([
                         "MenuItem" => $menuItem,
                         "AttributesHTML" => $menuItem->getAttributesHTML(),
                         "Title" => $title,
@@ -1139,7 +1139,7 @@ class LeftAndMain extends Controller implements PermissionProvider
                         "HasCSSIcon" => $hasCSSIcon,
                         "Link" => $menuItem->url,
                         "LinkingMode" => $linkingmode
-                    )));
+                    ]));
                 }
             }
             if ($menuIconStyling) {
@@ -1230,12 +1230,12 @@ class LeftAndMain extends Controller implements PermissionProvider
      */
     public function Breadcrumbs($unlinked = false)
     {
-        $items = new ArrayList(array(
-            new ArrayData(array(
+        $items = new ArrayList([
+            new ArrayData([
                 'Title' => $this->menu_title(),
                 'Link' => ($unlinked) ? false : $this->Link()
-            ))
-        ));
+            ])
+        ]);
 
         return $items;
     }
@@ -1272,7 +1272,7 @@ class LeftAndMain extends Controller implements PermissionProvider
             throw new InvalidArgumentException(sprintf('Invalid filter class passed: %s', $filterClass));
         }
 
-        return $this->searchFilterCache = Injector::inst()->createWithArgs($filterClass, array($params));
+        return $this->searchFilterCache = Injector::inst()->createWithArgs($filterClass, [$params]);
     }
 
     /**
@@ -1363,7 +1363,7 @@ class LeftAndMain extends Controller implements PermissionProvider
         );
         return $this->getResponseNegotiator()->respond(
             $this->getRequest(),
-            array('currentform' => array($this, 'EmptyForm'))
+            ['currentform' => [$this, 'EmptyForm']]
         );
     }
 
@@ -1482,11 +1482,11 @@ class LeftAndMain extends Controller implements PermissionProvider
             if ($request->isAjax() && $negotiator) {
                 $result = $form->forTemplate();
 
-                return $negotiator->respond($request, array(
+                return $negotiator->respond($request, [
                     'CurrentForm' => function () use ($result) {
                         return $result;
                     }
-                ));
+                ]);
             }
             return null;
         });
@@ -1658,9 +1658,9 @@ class LeftAndMain extends Controller implements PermissionProvider
 
         Requirements::clear();
         Requirements::css('silverstripe/admin: dist/css/LeftAndMain_printable.css');
-        return array(
+        return [
             "PrintForm" => $form
-        );
+        ];
     }
 
     /**
@@ -1965,14 +1965,14 @@ class LeftAndMain extends Controller implements PermissionProvider
 
     public function providePermissions()
     {
-        $perms = array(
-            "CMS_ACCESS_LeftAndMain" => array(
+        $perms = [
+            "CMS_ACCESS_LeftAndMain" => [
                 'name' => _t(__CLASS__ . '.ACCESSALLINTERFACES', 'Access to all CMS sections'),
                 'category' => _t('SilverStripe\\Security\\Permission.CMS_ACCESS_CATEGORY', 'CMS Access'),
                 'help' => _t(__CLASS__ . '.ACCESSALLINTERFACESHELP', 'Overrules more specific access settings.'),
                 'sort' => -100
-            )
-        );
+            ]
+        ];
 
         // Add any custom ModelAdmin subclasses. Can't put this on ModelAdmin itself
         // since its marked abstract, and needs to be singleton instanciated.
@@ -1997,15 +1997,15 @@ class LeftAndMain extends Controller implements PermissionProvider
                 $code = reset($code);
             }
             $title = LeftAndMain::menu_title($class);
-            $perms[$code] = array(
+            $perms[$code] = [
                 'name' => _t(
                     'SilverStripe\\CMS\\Controllers\\CMSMain.ACCESS',
                     "Access to '{title}' section",
                     "Item in permission selection identifying the admin section. Example: Access to 'Files & Images'",
-                    array('title' => $title)
+                    ['title' => $title]
                 ),
                 'category' => _t('SilverStripe\\Security\\Permission.CMS_ACCESS_CATEGORY', 'CMS Access')
-            );
+            ];
         }
 
         return $perms;

--- a/code/MemberImportForm.php
+++ b/code/MemberImportForm.php
@@ -50,7 +50,7 @@ class MemberImportForm extends Form
                 . 'multiple groups can be separated by comma. Existing group memberships are not cleared.</li>'
                 . '</ul>'
                 . '</div>',
-                array('columns' => $columns)
+                ['columns' => $columns]
             );
 
             $fields = new FieldList(
@@ -63,7 +63,7 @@ class MemberImportForm extends Form
                     ))
                 )
             );
-            $fileField->getValidator()->setAllowedExtensions(array('csv'));
+            $fileField->getValidator()->setAllowedExtensions(['csv']);
         }
 
         if (!$actions) {
@@ -92,33 +92,33 @@ class MemberImportForm extends Form
 
         // optionally set group relation
         if ($this->group) {
-            $loader->setGroups(array($this->group));
+            $loader->setGroups([$this->group]);
         }
 
         // load file
         $result = $loader->load($data['CsvFile']['tmp_name']);
 
         // result message
-        $msgArr = array();
+        $msgArr = [];
         if ($result->CreatedCount()) {
             $msgArr[] = _t(
                 __CLASS__ . '.ResultCreated',
                 'Created {count} members',
-                array('count' => $result->CreatedCount())
+                ['count' => $result->CreatedCount()]
             );
         }
         if ($result->UpdatedCount()) {
             $msgArr[] = _t(
                 __CLASS__ . '.ResultUpdated',
                 'Updated {count} members',
-                array('count' => $result->UpdatedCount())
+                ['count' => $result->UpdatedCount()]
             );
         }
         if ($result->DeletedCount()) {
             $msgArr[] = _t(
                 __CLASS__ . '.ResultDeleted',
                 'Deleted {count} members',
-                array('count' => $result->DeletedCount())
+                ['count' => $result->DeletedCount()]
             );
         }
         $msg = ($msgArr) ? implode(',', $msgArr) : _t(__CLASS__ . '.ResultNone', 'No changes');

--- a/code/ModalController.php
+++ b/code/ModalController.php
@@ -13,10 +13,10 @@ use SilverStripe\Forms\Form;
  */
 class ModalController extends RequestHandler
 {
-    private static $allowed_actions = array(
+    private static $allowed_actions = [
         'EditorExternalLink',
         'EditorEmailLink',
-    );
+    ];
 
     public function Link($action = null)
     {

--- a/code/ModelAdmin.php
+++ b/code/ModelAdmin.php
@@ -82,14 +82,14 @@ abstract class ModelAdmin extends LeftAndMain
      */
     private static $menu_icon_class = 'font-icon-database';
 
-    private static $allowed_actions = array(
+    private static $allowed_actions = [
         'ImportForm',
         'SearchForm'
-    );
+    ];
 
-    private static $url_handlers = array(
+    private static $url_handlers = [
         '$ModelClass/$Action' => 'handleAction'
-    );
+    ];
 
     /**
      * @var string The {@link \SilverStripe\ORM\DataObject} sub-class being managed during this object's lifetime.
@@ -421,7 +421,7 @@ abstract class ModelAdmin extends LeftAndMain
         $forms = new ArrayList();
 
         foreach ($models as $tab => $options) {
-            $forms->push(new ArrayData(array(
+            $forms->push(new ArrayData([
                 'Title' => $options['title'],
                 'Tab' => $tab,
                 // `getManagedModels` did not always return a `dataClass` attribute
@@ -429,7 +429,7 @@ abstract class ModelAdmin extends LeftAndMain
                 'ClassName' => isset($options['dataClass']) ? $options['dataClass'] : $tab,
                 'Link' => $this->Link($this->sanitiseClassName($tab)),
                 'LinkOrCurrent' => ($tab == $this->modelTab) ? 'current' : 'link'
-            )));
+            ]));
         }
 
         return $forms;
@@ -464,7 +464,7 @@ abstract class ModelAdmin extends LeftAndMain
     {
         $models = $this->config()->get('managed_models');
         if (is_string($models)) {
-            $models = array($models);
+            $models = [$models];
         }
         if (!count($models ?? [])) {
             throw new \RuntimeException(
@@ -507,7 +507,7 @@ abstract class ModelAdmin extends LeftAndMain
             }
         }
 
-        $importers = array();
+        $importers = [];
         foreach ($importerClasses as $modelClass => $importerClass) {
             $importers[$modelClass] = new $importerClass($modelClass);
         }
@@ -552,18 +552,18 @@ abstract class ModelAdmin extends LeftAndMain
         $spec = $importer->getImportSpec();
         $specFields = new ArrayList();
         foreach ($spec['fields'] as $name => $desc) {
-            $specFields->push(new ArrayData(array('Name' => $name, 'Description' => $desc)));
+            $specFields->push(new ArrayData(['Name' => $name, 'Description' => $desc]));
         }
         $specRelations = new ArrayList();
         foreach ($spec['relations'] as $name => $desc) {
-            $specRelations->push(new ArrayData(array('Name' => $name, 'Description' => $desc)));
+            $specRelations->push(new ArrayData(['Name' => $name, 'Description' => $desc]));
         }
-        $specHTML = $this->customise(array(
+        $specHTML = $this->customise([
             'ClassName' => $this->sanitiseClassName($this->modelClass),
             'ModelName' => Convert::raw2att($modelName),
             'Fields' => $specFields,
             'Relations' => $specRelations,
-        ))->renderWith($this->getTemplatesWithSuffix('_ImportSpec'));
+        ])->renderWith($this->getTemplatesWithSuffix('_ImportSpec'));
 
         $fields->push(new LiteralField("SpecFor{$modelName}", $specHTML));
         $fields->push(
@@ -642,21 +642,21 @@ abstract class ModelAdmin extends LeftAndMain
                 $message .= _t(
                     'SilverStripe\\Admin\\ModelAdmin.IMPORTEDRECORDS',
                     "Imported {count} records.",
-                    array('count' => $results->CreatedCount())
+                    ['count' => $results->CreatedCount()]
                 );
             }
             if ($results && $results->UpdatedCount()) {
                 $message .= _t(
                     'SilverStripe\\Admin\\ModelAdmin.UPDATEDRECORDS',
                     "Updated {count} records.",
-                    array('count' => $results->UpdatedCount())
+                    ['count' => $results->UpdatedCount()]
                 );
             }
             if ($results->DeletedCount()) {
                 $message .= _t(
                     'SilverStripe\\Admin\\ModelAdmin.DELETEDRECORDS',
                     "Deleted {count} records.",
-                    array('count' => $results->DeletedCount())
+                    ['count' => $results->DeletedCount()]
                 );
             }
             if (!$results->CreatedCount() && !$results->UpdatedCount()) {

--- a/code/SecurityAdmin.php
+++ b/code/SecurityAdmin.php
@@ -47,7 +47,7 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider
 
     private static $menu_icon_class = 'font-icon-torsos-all';
 
-    private static $allowed_actions = array(
+    private static $allowed_actions = [
         'EditForm',
         'MemberImportForm',
         'memberimport',
@@ -56,7 +56,7 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider
         'groups',
         'users',
         'roles'
-    );
+    ];
 
     /**
      * Shortcut action for setting the correct active tab.
@@ -140,15 +140,15 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider
         );
         /** @var GridFieldDataColumns $columns */
         $columns = $groupList->getConfig()->getComponentByType(GridFieldDataColumns::class);
-        $columns->setDisplayFields(array(
+        $columns->setDisplayFields([
             'Breadcrumbs' => Group::singleton()->fieldLabel('Title')
-        ));
-        $columns->setFieldFormatting(array(
+        ]);
+        $columns->setFieldFormatting([
             'Breadcrumbs' => function ($val, $item) {
                 /** @var Group $item */
                 return Convert::raw2xml($item->getBreadcrumbs(' > '));
             }
-        ));
+        ]);
 
         $fields = FieldList::create(
             TabSet::create(
@@ -216,10 +216,10 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider
         Requirements::javascript('silverstripe/admin: client/dist/js/MemberImportForm.js');
         Requirements::css('silverstripe/admin: client/dist/styles/bundle.css');
 
-        return $this->renderWith('BlankPage', array(
+        return $this->renderWith('BlankPage', [
             'Form' => $this->MemberImportForm()->forTemplate(),
             'Content' => ' '
-        ));
+        ]);
     }
 
     /**
@@ -248,10 +248,10 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider
         Requirements::javascript('silverstripe/admin: client/dist/js/MemberImportForm.js');
         Requirements::css('silverstripe/admin: client/dist/styles/bundle.css');
 
-        return $this->renderWith('BlankPage', array(
+        return $this->renderWith('BlankPage', [
             'Content' => ' ',
             'Form' => $this->GroupImportForm()->forTemplate()
-        ));
+        ]);
     }
 
     /**
@@ -291,20 +291,20 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider
             // admin/security/EditForm/field/Groups/item/2/ItemEditForm/field/Members/item/1/edit
             $firstCrumb = $crumbs->shift();
             if ($params['FieldName'] == 'Groups') {
-                $crumbs->unshift(new ArrayData(array(
+                $crumbs->unshift(new ArrayData([
                     'Title' => Group::singleton()->i18n_plural_name(),
                     'Link' => $this->Link('groups')
-                )));
+                ]));
             } elseif ($params['FieldName'] == 'Users') {
-                $crumbs->unshift(new ArrayData(array(
+                $crumbs->unshift(new ArrayData([
                     'Title' => _t(__CLASS__ . '.Users', 'Users'),
                     'Link' => $this->Link('users')
-                )));
+                ]));
             } elseif ($params['FieldName'] == 'Roles') {
-                $crumbs->unshift(new ArrayData(array(
+                $crumbs->unshift(new ArrayData([
                     'Title' => _t(__CLASS__ . '.TABROLES', 'Roles'),
                     'Link' => $this->Link('roles')
-                )));
+                ]));
             }
             $crumbs->unshift($firstCrumb);
         }
@@ -315,7 +315,7 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider
     public function providePermissions()
     {
         $title = $this->menu_title();
-        return array(
+        return [
             "CMS_ACCESS_SecurityAdmin" => [
                 'name' => _t(
                     'SilverStripe\\CMS\\Controllers\\CMSMain.ACCESS',
@@ -326,9 +326,9 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider
                 'help' => _t(
                     __CLASS__ . '.ACCESS_HELP',
                     'Allow viewing, adding and editing users, as well as assigning permissions and roles to them.'
-                )
+                ),
             ],
-            'EDIT_PERMISSIONS' => array(
+            'EDIT_PERMISSIONS' => [
                 'name' => _t(__CLASS__ . '.EDITPERMISSIONS', 'Manage permissions for groups'),
                 'category' => _t(
                     'SilverStripe\\Security\\Permission.PERMISSIONS_CATEGORY',
@@ -339,9 +339,9 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider
                     'Ability to edit Permissions and IP Addresses for a group.'
                     . ' Requires the "Access to \'Security\' section" permission.'
                 ),
-                'sort' => 0
-            ),
-            'APPLY_ROLES' => array(
+                'sort' => 0,
+            ],
+            'APPLY_ROLES' => [
                 'name' => _t(__CLASS__ . '.APPLY_ROLES', 'Apply roles to groups'),
                 'category' => _t(
                     'SilverStripe\\Security\\Permission.PERMISSIONS_CATEGORY',
@@ -352,8 +352,8 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider
                     'Ability to edit the roles assigned to a group.'
                     . ' Requires the "Access to \'Users\' section" permission.'
                 ),
-                'sort' => 0
-            )
-        );
+                'sort' => 0,
+            ],
+        ];
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -13,4 +13,7 @@
 		<exclude name="Generic.Files.LineLength.TooLong" />
 		<exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
 	</rule>
+
+	<!-- use short array syntax -->
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax" />
 </ruleset>

--- a/tests/php/CMSMenuItemTest.php
+++ b/tests/php/CMSMenuItemTest.php
@@ -11,7 +11,7 @@ class CMSMenuItemTest extends SapphireTest
     public function testAttributes()
     {
         $menuItem = new CMSMenuItem('Foo', 'foo');
-        $exampleAttributes = array('title' => 'foo bar', 'disabled' => true, 'data-foo' => '<something>');
+        $exampleAttributes = ['title' => 'foo bar', 'disabled' => true, 'data-foo' => '<something>'];
 
         $this->assertEquals(
             'title="foo bar" disabled="disabled" data-foo="&lt;something&gt;"',
@@ -19,7 +19,7 @@ class CMSMenuItemTest extends SapphireTest
             'Attributes appear correctly when passed as an argument'
         );
 
-        $emptyAttributes = array('empty' => '');
+        $emptyAttributes = ['empty' => ''];
         $this->assertEquals(
             '',
             $menuItem->getAttributesHTML($emptyAttributes),

--- a/tests/php/CMSMenuTest.php
+++ b/tests/php/CMSMenuTest.php
@@ -79,9 +79,9 @@ class CMSMenuTest extends SapphireTest implements TestOnly
     {
         CMSMenu::clear_menu();
 
-        CMSMenu::add_link('LinkCode', 'link title', 'http://www.example.com', -2, array(
+        CMSMenu::add_link('LinkCode', 'link title', 'http://www.example.com', -2, [
             'target' => '_blank'
-        ));
+        ]);
 
         $menuItems = CMSMenu::get_menu_items();
         /** @var CMSMenuItem $menuItem */

--- a/tests/php/CMSProfileControllerTest.php
+++ b/tests/php/CMSProfileControllerTest.php
@@ -20,7 +20,7 @@ class CMSProfileControllerTest extends FunctionalTest
         $anotherMember = $this->objFromFixture(Member::class, 'user2');
         $this->logInAs($member);
 
-        $response = $this->post('admin/myprofile/EditForm', array(
+        $response = $this->post('admin/myprofile/EditForm', [
             'action_save' => 1,
             'ID' => $anotherMember->ID,
             'FirstName' => 'JoeEdited',
@@ -29,7 +29,7 @@ class CMSProfileControllerTest extends FunctionalTest
             'Locale' => $member->Locale,
             'Password[_Password]' => 'password',
             'Password[_ConfirmPassword]' => 'password',
-        ));
+        ]);
 
         $anotherMember = $this->objFromFixture(Member::class, 'user2');
 
@@ -41,7 +41,7 @@ class CMSProfileControllerTest extends FunctionalTest
         $member = $this->objFromFixture(Member::class, 'user3');
         $this->logInAs($member);
 
-        $response = $this->post('admin/myprofile/EditForm', array(
+        $response = $this->post('admin/myprofile/EditForm', [
             'action_save' => 1,
             'ID' => $member->ID,
             'FirstName' => 'JoeEdited',
@@ -50,7 +50,7 @@ class CMSProfileControllerTest extends FunctionalTest
             'Locale' => $member->Locale,
             'Password[_Password]' => 'password',
             'Password[_ConfirmPassword]' => 'password',
-        ));
+        ]);
 
         $member = $this->objFromFixture(Member::class, 'user3');
 
@@ -67,7 +67,7 @@ class CMSProfileControllerTest extends FunctionalTest
         $member = $this->objFromFixture(Member::class, 'user1');
         $this->logInAs($member);
 
-        $response = $this->post('admin/myprofile/EditForm', array(
+        $response = $this->post('admin/myprofile/EditForm', [
             'action_save' => 1,
             'ID' => $member->ID,
             'FirstName' => 'JoeEdited',
@@ -76,7 +76,7 @@ class CMSProfileControllerTest extends FunctionalTest
             'Locale' => $member->Locale,
             'Password[_Password]' => 'password',
             'Password[_ConfirmPassword]' => 'password',
-        ));
+        ]);
 
         $member = $this->objFromFixture(Member::class, 'user1');
 

--- a/tests/php/LeftAndMainTest.php
+++ b/tests/php/LeftAndMainTest.php
@@ -32,19 +32,19 @@ class LeftAndMainTest extends FunctionalTest
         $assetsDir = File::join_paths($base->getRelativePath(), 'tests/php/assets');
 
         LeftAndMain::config()
-            ->update('extra_requirements_css', array(
+            ->update('extra_requirements_css', [
                 $assetsDir.'/LeftAndMainTest.css',
                 $assetsDir. '/LeftAndMainTestWithOptions.css' => [
                     'media' => 'print',
                     'crossorigin' => 'anonymous'
                 ],
-            ))
-            ->update('extra_requirements_javascript', array(
+            ])
+            ->update('extra_requirements_javascript', [
                 $assetsDir. '/LeftAndMainTest.js',
                 $assetsDir. '/LeftAndMainTestWithOptions.js' => [
                     'crossorigin' => 'anonymous'
                 ],
-            ));
+            ]);
 
         Requirements::set_combined_files_enabled(false);
     }
@@ -133,7 +133,7 @@ class LeftAndMainTest extends FunctionalTest
         $menuItems = LeftAndMain::singleton()->MainMenu(false);
         $this->assertEquals(
             $menuItems->column('Code'),
-            array(),
+            [],
             'Without valid login, members cant access any menu entries'
         );
 
@@ -145,10 +145,10 @@ class LeftAndMainTest extends FunctionalTest
         sort($menuItems);
 
         $this->assertEquals(
-            array(
+            [
                 'SilverStripe-Admin-CMSProfileController',
                 'SilverStripe-Admin-SecurityAdmin'
-            ),
+            ],
             $menuItems,
             'Groups with limited access can only access the interfaces they have permissions for'
         );

--- a/tests/php/ModelAdminTest.php
+++ b/tests/php/ModelAdminTest.php
@@ -90,10 +90,10 @@ class ModelAdminTest extends FunctionalTest
         $request->setSession(new Session([]));
         $admin->setRequest($request);
         $admin->doInit();
-        $this->assertEquals($admin->getExportFields(), array(
+        $this->assertEquals($admin->getExportFields(), [
             'Name' => 'Name',
             'Position' => 'Position'
-        ));
+        ]);
     }
 
     public function testGetGridField()

--- a/tests/php/ModelAdminTest/Contact.php
+++ b/tests/php/ModelAdminTest/Contact.php
@@ -8,12 +8,12 @@ use SilverStripe\ORM\DataObject;
 class Contact extends DataObject implements TestOnly
 {
     private static $table_name = 'ModelAdminTest_Contact';
-    private static $db = array(
+    private static $db = [
         'Name' => 'Varchar',
         'Phone' => 'Varchar',
-    );
-    private static $summary_fields = array(
+    ];
+    private static $summary_fields = [
         'Name' => 'Name',
         'Phone' => 'Phone'
-    );
+    ];
 }

--- a/tests/php/ModelAdminTest/ContactAdmin.php
+++ b/tests/php/ModelAdminTest/ContactAdmin.php
@@ -10,9 +10,9 @@ class ContactAdmin extends ModelAdmin implements TestOnly
 {
     private static $url_segment = 'contactadmin';
 
-    private static $managed_models = array(
+    private static $managed_models = [
         Contact::class,
-    );
+    ];
 
     public function Link($action = null)
     {

--- a/tests/php/ModelAdminTest/Player.php
+++ b/tests/php/ModelAdminTest/Player.php
@@ -8,11 +8,11 @@ use SilverStripe\ORM\DataObject;
 class Player extends DataObject implements TestOnly
 {
     private static $table_name = 'ModelAdminTest_Player';
-    private static $db = array(
+    private static $db = [
         'Name' => 'Varchar',
         'Position' => 'Varchar',
-    );
-    private static $has_one = array(
+    ];
+    private static $has_one = [
         'Contact' => Contact::class
-    );
+    ];
 }

--- a/tests/php/ModelAdminTest/PlayerAdmin.php
+++ b/tests/php/ModelAdminTest/PlayerAdmin.php
@@ -10,16 +10,16 @@ class PlayerAdmin extends ModelAdmin implements TestOnly
 {
     private static $url_segment = 'playeradmin';
 
-    private static $managed_models = array(
+    private static $managed_models = [
         Player::class
-    );
+    ];
 
     public function getExportFields()
     {
-        return array(
+        return [
             'Name' => 'Name',
             'Position' => 'Position'
-        );
+        ];
     }
 
     public function Link($action = null)

--- a/tests/php/SecurityAdminTest.php
+++ b/tests/php/SecurityAdminTest.php
@@ -54,7 +54,7 @@ class SecurityAdminTest extends FunctionalTest
 
         $group = $this->objFromFixture(Group::class, 'admin');
 
-        Config::modify()->merge(Permission::class, 'hidden_permissions', array('CMS_ACCESS_ReportAdmin'));
+        Config::modify()->merge(Permission::class, 'hidden_permissions', ['CMS_ACCESS_ReportAdmin']);
         $response = $this->get(sprintf('admin/security/EditForm/field/Groups/item/%d/edit', $group->ID));
 
         $this->assertStringContainsString(


### PR DESCRIPTION
This has been done on various other modules already - looks like this one was missed at the time.
The phpcs rule was taken from cms - IMO it makes a lot of sense to add this to linting just to keep things tidy. It's part of PSR12 so we'll likely globally adopt it anyway.

## Parent issue
- https://github.com/silverstripe/silverstripe-admin/issues/1347