### PR TITLE
BUG case error in SelectionGroup template

### DIFF
--- a/themes/cms-forms/templates/SilverStripe/Forms/SelectionGroup.ss
+++ b/themes/cms-forms/templates/SilverStripe/Forms/SelectionGroup.ss
@@ -23,7 +23,7 @@
 				<% if $FieldList %>
 					<div class="selection-group selection-group__item__fieldlist" id="$ID">
 						<% loop $FieldList %>
-							$Fieldholder
+							$FieldHolder
 						<% end_loop %>
 					</div>
 				<% end_if %>


### PR DESCRIPTION
Rescues https://github.com/silverstripe/silverstripe-admin/pull/997
Fixes a bug without touching APIs so makes sense to target 1.11

Note that the underlying issue is resolved in https://github.com/silverstripe/silverstripe-framework/pull/10470 - but this should be fixed here a) for tidyness and b) because someone could be using 1.11.x of admin with some version of framework where that PR isn't merged.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10350