### PR TITLE
API Make some methods static for ModelAdmin

### DIFF
--- a/code/SecurityAdmin.php
+++ b/code/SecurityAdmin.php
@@ -62,7 +62,7 @@ class SecurityAdmin extends ModelAdmin implements PermissionProvider
 
     private static $menu_icon_class = 'font-icon-torsos-all';
 
-    public function getManagedModels()
+    public static function getManagedModels()
     {
         $models = parent::getManagedModels();
         // Ensure tab titles can be localised

--- a/tests/php/ModelAdminTest.php
+++ b/tests/php/ModelAdminTest.php
@@ -166,9 +166,7 @@ class ModelAdminTest extends FunctionalTest
 
     public function testGetManagedModels()
     {
-        $admin = new ModelAdminTest\MultiModelAdmin();
-
-        $models = $admin->getManagedModels();
+        $models = ModelAdminTest\MultiModelAdmin::getManagedModels();
 
         $this->assertEquals(
             [
@@ -209,30 +207,8 @@ class ModelAdminTest extends FunctionalTest
 
     public function testGetManagedModelTabs()
     {
-        $mock = $this->getMockBuilder(ModelAdminTest\MultiModelAdmin::class)
-            ->setMethods(['getManagedModels'])
-            ->getMock();
-
-        // `getManagedModelTabs` relies on `getManagedModels` whose output format has changed within the 4.x line.
-        // We need to mock `getManagedModels` so it returns both the legacy and updated format.
-        $mock->expects($this->atLeastOnce())
-            ->method('getManagedModels')
-            ->will($this->returnValue([
-                'Player' => [
-                    'dataClass' => Player::class,
-                    'title' => 'Ice Hockey Players'
-                ],
-                Player::class => [
-                    'title' => 'Rugby Players'
-                ],
-                'cricket-players' => [
-                    'dataClass' => Player::class,
-                    'title' => 'Cricket Players',
-                ],
-            ]));
-
-
-        $tabs = $mock->getManagedModelTabs()->toNestedArray();
+        $admin = new ModelAdminTest\MultiModelAdmin();
+        $tabs = $admin->getManagedModelTabs()->toNestedArray();
 
         $this->assertEquals(
             [
@@ -275,11 +251,11 @@ class ModelAdminTest extends FunctionalTest
     {
         $admin = new ModelAdminTest\MultiModelAdmin();
         $this->assertEquals(
-            'admin/multi/' . $this->sanitiseClassName(Contact::class),
+            'admin/multi/' . ModelAdminTest\MultiModelAdmin::sanitiseClassName(Contact::class),
             $admin->getLinkForModelClass(Contact::class)
         );
         $this->assertEquals(
-            'admin/multi/' . $this->sanitiseClassName(Contact::class),
+            'admin/multi/' . ModelAdminTest\MultiModelAdmin::sanitiseClassName(Contact::class),
             $admin->getLinkForModelClass(ContactSubclass::class)
         );
         $this->assertEquals(
@@ -299,7 +275,7 @@ class ModelAdminTest extends FunctionalTest
     {
         $admin = new ModelAdminTest\MultiModelAdmin();
         $this->assertEquals(
-            'admin/multi/' . $this->sanitiseClassName(Contact::class),
+            'admin/multi/' . ModelAdminTest\MultiModelAdmin::sanitiseClassName(Contact::class),
             $admin->getLinkForModelTab(Contact::class)
         );
         $this->assertEquals(
@@ -307,7 +283,7 @@ class ModelAdminTest extends FunctionalTest
             $admin->getLinkForModelTab('Player')
         );
         $this->assertEquals(
-            'admin/multi/' . $this->sanitiseClassName(Player::class),
+            'admin/multi/' . ModelAdminTest\MultiModelAdmin::sanitiseClassName(Player::class),
             $admin->getLinkForModelTab(Player::class)
         );
         $this->assertEquals(
@@ -327,7 +303,7 @@ class ModelAdminTest extends FunctionalTest
     {
         $admin = new ModelAdminTest\MultiModelAdmin();
         $contact = $this->objFromFixture(Contact::class, 'sam');
-        $sanitisedContact = $this->sanitiseClassName(Contact::class);
+        $sanitisedContact = ModelAdminTest\MultiModelAdmin::sanitiseClassName(Contact::class);
         $this->assertEquals(
             "admin/multi/$sanitisedContact/EditForm/field/$sanitisedContact/item/$contact->ID",
             $admin->getEditLinkForManagedDataObject($contact)
@@ -369,16 +345,10 @@ class ModelAdminTest extends FunctionalTest
 
     public function testIsManagedModel()
     {
-        $admin = new ModelAdminTest\MultiModelAdmin();
-        $this->assertTrue($admin->isManagedModel(Contact::class));
-        $this->assertTrue($admin->isManagedModel(ContactSubclass::class));
-        $this->assertTrue($admin->isManagedModel(Player::class));
-        $this->assertTrue($admin->isManagedModel('cricket-players'));
-        $this->assertFalse($admin->isManagedModel('not-managed'));
-    }
-
-    private function sanitiseClassName(string $className): string
-    {
-        return str_replace('\\', '-', $className);
+        $this->assertTrue(ModelAdminTest\MultiModelAdmin::isManagedModel(Contact::class));
+        $this->assertTrue(ModelAdminTest\MultiModelAdmin::isManagedModel(ContactSubclass::class));
+        $this->assertTrue(ModelAdminTest\MultiModelAdmin::isManagedModel(Player::class));
+        $this->assertTrue(ModelAdminTest\MultiModelAdmin::isManagedModel('cricket-players'));
+        $this->assertFalse(ModelAdminTest\MultiModelAdmin::isManagedModel('not-managed'));
     }
 }

--- a/tests/php/ModelAdminTest/ContactAdmin.php
+++ b/tests/php/ModelAdminTest/ContactAdmin.php
@@ -17,7 +17,7 @@ class ContactAdmin extends ModelAdmin implements TestOnly
     public function Link($action = null)
     {
         if (!$action) {
-            $action = $this->sanitiseClassName($this->modelClass);
+            $action = static::sanitiseClassName($this->modelClass);
         }
         return Controller::join_links('ContactAdmin', $action, '/');
     }

--- a/tests/php/ModelAdminTest/PlayerAdmin.php
+++ b/tests/php/ModelAdminTest/PlayerAdmin.php
@@ -25,7 +25,7 @@ class PlayerAdmin extends ModelAdmin implements TestOnly
     public function Link($action = null)
     {
         if (!$action) {
-            $action = $this->sanitiseClassName($this->modelClass);
+            $action = static::sanitiseClassName($this->modelClass);
         }
         return Controller::join_links('PlayerAdmin', $action, '/');
     }


### PR DESCRIPTION
These methods had no need to be instance methods and are likely candidates for wanting to call without having an instance - which normally means just creating a singleton.

## NOTE
This PR includes https://github.com/silverstripe/silverstripe-admin/pull/1360 - that PR _must_ be merged up and any conflicts resolved before this PR gets merged.

Also depends on https://github.com/silverstripe/silverstripe-frameworktest/pull/123 and https://github.com/silverstripe/silverstripe-versioned-admin/pull/254 for CI to go green (it's a chicken-and-egg situation)

## Parent issue
- https://github.com/silverstripe/silverstripe-admin/issues/1354