### PR TITLE
NEW New API for managing models in ModelAdmin

### DIFF
--- a/tests/php/ModelAdminTest.yml
+++ b/tests/php/ModelAdminTest.yml
@@ -6,6 +6,16 @@ SilverStripe\Admin\Tests\ModelAdminTest\Contact:
     Name: ingo
     Phone: 04 987 6543
 
+SilverStripe\Admin\Tests\ModelAdminTest\ContactSubclass:
+  danie:
+    Name: Danie
+    Phone: n/a
+    Address: 101 some street
+
+SilverStripe\Admin\Tests\ModelAdminTest\Player:
+  amy:
+    Name: Amy
+
 SilverStripe\Security\Member:
   admin:
     FirstName: admin

--- a/tests/php/ModelAdminTest/ContactSubclass.php
+++ b/tests/php/ModelAdminTest/ContactSubclass.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\Admin\Tests\ModelAdminTest;
+
+use SilverStripe\Dev\TestOnly;
+
+class ContactSubclass extends Contact implements TestOnly
+{
+    private static $table_name = 'ModelAdminTest_ContactSubclass';
+    private static $db = [
+        'Address' => 'Text',
+    ];
+}


### PR DESCRIPTION
Makes it easier to manage models in a ModelAdmin, e.g. for implementing `CMSEditLink()` from the `CMSPreviewable` interface and checking if models are actually managed in the admin.

## Parent issue
- https://github.com/silverstripe/silverstripe-admin/issues/1354