### PR TITLE
ENH Records can be made previewable with an extension

### DIFF
--- a/code/Forms/GridFieldDetailFormPreviewExtension.php
+++ b/code/Forms/GridFieldDetailFormPreviewExtension.php
@@ -17,7 +17,7 @@ class GridFieldDetailFormPreviewExtension extends Extension
     {
         $record = $this->owner->getRecord();
         // See LeftAndMain::getEditForm()
-        if ($record instanceof CMSPreviewable) {
+        if ($record instanceof CMSPreviewable || $record->has_extension(CMSPreviewable::class)) {
             // Mark as previewable.
             $form->addExtraClass('cms-previewable');
             // Add preview controls.

--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -1444,7 +1444,7 @@ class LeftAndMain extends Controller implements PermissionProvider
         // Added in-line to the form, but plucked into different view by frontend scripts.
         if ($record instanceof CMSPreviewable || $record->has_extension(CMSPreviewable::class)) {
             /** @skipUpgrade */
-            $navField = new LiteralField('SilverStripeNavigator', $this->getSilverStripeNavigator());
+            $navField = new LiteralField('SilverStripeNavigator', $this->getSilverStripeNavigator($record));
             $navField->setAllowHTML(true);
             $fields->push($navField);
         }
@@ -1673,11 +1673,13 @@ class LeftAndMain extends Controller implements PermissionProvider
      *
      * @return DBHTMLText
      */
-    public function getSilverStripeNavigator()
+    public function getSilverStripeNavigator(?DataObject $record = null)
     {
-        $page = $this->currentPage();
-        if ($page instanceof CMSPreviewable || $page->has_extension(CMSPreviewable::class)) {
-            $navigator = new SilverStripeNavigator($page);
+        if (!$record) {
+            $record = $this->currentPage();
+        }
+        if ($record && (($record instanceof CMSPreviewable) || $record->has_extension(CMSPreviewable::class))) {
+            $navigator = new SilverStripeNavigator($record);
             return $navigator->renderWith($this->getTemplatesWithSuffix('_SilverStripeNavigator'));
         }
         return null;

--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -1442,7 +1442,7 @@ class LeftAndMain extends Controller implements PermissionProvider
         }
 
         // Added in-line to the form, but plucked into different view by frontend scripts.
-        if ($record instanceof CMSPreviewable) {
+        if ($record instanceof CMSPreviewable || $record->has_extension(CMSPreviewable::class)) {
             /** @skipUpgrade */
             $navField = new LiteralField('SilverStripeNavigator', $this->getSilverStripeNavigator());
             $navField->setAllowHTML(true);
@@ -1497,7 +1497,7 @@ class LeftAndMain extends Controller implements PermissionProvider
         });
 
         // Announce the capability so the frontend can decide whether to allow preview or not.
-        if ($record instanceof CMSPreviewable) {
+        if ($record instanceof CMSPreviewable || $record->has_extension(CMSPreviewable::class)) {
             $form->addExtraClass('cms-previewable');
         }
         $form->addExtraClass('fill-height');
@@ -1676,7 +1676,7 @@ class LeftAndMain extends Controller implements PermissionProvider
     public function getSilverStripeNavigator()
     {
         $page = $this->currentPage();
-        if ($page instanceof CMSPreviewable) {
+        if ($page instanceof CMSPreviewable || $page->has_extension(CMSPreviewable::class)) {
             $navigator = new SilverStripeNavigator($page);
             return $navigator->renderWith($this->getTemplatesWithSuffix('_SilverStripeNavigator'));
         }

--- a/code/Navigator/SilverStripeNavigator.php
+++ b/code/Navigator/SilverStripeNavigator.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Admin\Navigator;
 
+use InvalidArgumentException;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\CMSPreviewable;
@@ -30,8 +31,11 @@ class SilverStripeNavigator extends ViewableData
     /**
      * @param DataObject|CMSPreviewable $record
      */
-    public function __construct(CMSPreviewable $record)
+    public function __construct(DataObject $record)
     {
+        if (!($record instanceof CMSPreviewable) && !$record->has_extension(CMSPreviewable::class)) {
+            throw new InvalidArgumentException('$record must implement or have an extension that implements CMSPreviewable.');
+        }
         parent::__construct();
         $this->record = $record;
     }

--- a/code/Navigator/SilverStripeNavigatorItem.php
+++ b/code/Navigator/SilverStripeNavigatorItem.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Admin\Navigator;
 
+use InvalidArgumentException;
 use SilverStripe\ORM\CMSPreviewable;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
@@ -26,8 +27,11 @@ abstract class SilverStripeNavigatorItem extends ViewableData
     /**
      * @param DataObject|CMSPreviewable $record
      */
-    public function __construct(CMSPreviewable $record)
+    public function __construct(DataObject $record)
     {
+        if (!($record instanceof CMSPreviewable) && !$record->has_extension(CMSPreviewable::class)) {
+            throw new InvalidArgumentException('$record must implement or have an extension that implements CMSPreviewable.');
+        }
         parent::__construct();
         $this->record = $record;
     }


### PR DESCRIPTION
Note: There are currently few if any tests for previewable objects - that will come with https://github.com/silverstripe/silverstripe-admin/issues/1306

Requires https://github.com/silverstripe/silverstripe-cms/pull/2779 to be merged in at the same time

See the parent issue for code to test this locally.

## Parent issue
- https://github.com/silverstripe/silverstripe-admin/issues/1362