### PR TITLE
FIX Don't assume dataclass is in the spec.

### DIFF
--- a/code/ModelAdmin.php
+++ b/code/ModelAdmin.php
@@ -574,6 +574,9 @@ abstract class ModelAdmin extends LeftAndMain
         $classes = array_reverse(ClassInfo::ancestry($modelClass));
         foreach ($classes as $class) {
             foreach ($managed as $tab => $spec) {
+                if (!isset($spec['dataClass'])) {
+                    $spec['dataClass'] = $tab;
+                }
                 if ($spec['dataClass'] === $class) {
                     return $tab;
                 }

--- a/tests/php/ModelAdminTest.php
+++ b/tests/php/ModelAdminTest.php
@@ -367,6 +367,26 @@ class ModelAdminTest extends FunctionalTest
         $reflectionMethod->invoke($admin, 'cricket-players');
     }
 
+    public function testGetModelTabForModelClassNoSpec()
+    {
+        /** @var ModelAdmin $mock */
+        $mock = $this->getMockBuilder(ModelAdminTest\MultiModelAdmin::class)->getMock();
+
+        // `ModelTabForModelClass` relies on `getManagedModels` whose output format has changed within the 4.x line.
+        // We need to mock `getManagedModels` to test the legacy format.
+        $mock->expects($this->atLeastOnce())
+            ->method('getManagedModels')
+            ->will($this->returnValue([
+                Player::class => [
+                    'title' => 'Rugby Players'
+                ],
+            ]));
+
+        $reflectionMethod = new ReflectionMethod($mock, 'getModelTabForModelClass');
+        $reflectionMethod->setAccessible(true);
+        $this->assertSame(Player::class, $reflectionMethod->invoke($mock, Player::class));
+    }
+
     public function testIsManagedModel()
     {
         $admin = new ModelAdminTest\MultiModelAdmin();


### PR DESCRIPTION
Don't assume the dataclass is in the spec of `getManagedModels()` because subclasses may not include it.

## Parent issue
- https://github.com/silverstripe/silverstripe-admin/issues/1379