### PR TITLE
MNT Remove require-dev deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "silverstripe/frameworktest": "^1",
-        "squizlabs/php_codesniffer": "^3.7",
-        "nikic/php-parser": "^4.14.0",
-        "monolog/monolog": "^1.27.1"
+        "squizlabs/php_codesniffer": "^3.7"
     },
     "extra": {
         "expose": [


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/609

Requires the follow PRs be merged first:
- https://github.com/silverstripe/silverstripe-framework/pull/10558
- https://github.com/silverstripe/silverstripe-behat-extension/pull/231

These `require-dev` deps aren't required as they're in `require` for framework https://github.com/silverstripe/silverstripe-framework/blob/5/composer.json#L33

Fixes 
```
  Problem 1
    - silverstripe/framework 5.x-dev requires monolog/monolog ^3.2.0 -> found monolog/monolog[dev-main, 3.2.0, 3.x-dev (alias of dev-main)] but it conflicts with your root composer.json require (^1.27.1).
```
https://github.com/silverstripe/silverstripe-admin/actions/runs/3293533770/jobs/5430134747