### PR TITLE
FIX Cast absoluteUrl() argument to string

### DIFF
--- a/code/CMSEditLinkExtension.php
+++ b/code/CMSEditLinkExtension.php
@@ -85,7 +85,7 @@ class CMSEditLinkExtension extends Extension
         } else {
             $relativeLink = $owner->getCMSEditLinkForManagedDataObject($this->owner);
         }
-        return Director::absoluteURL($relativeLink);
+        return Director::absoluteURL((string) $relativeLink);
     }
 
     private function getCMSEditLinkForRelation(array $componentConfig, DataObject $obj, string $reciprocalRelation, FieldList $fields): string


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/642

Similar to https://github.com/silverstripe/silverstripe-elemental/pull/1029