### PR TITLE
Suppress admin error context for base 'CMS access' permission check (fixes #1443)

### DIFF
--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -182,6 +182,11 @@ class LeftAndMain extends Controller implements PermissionProvider
     private string $httpErrorMessage;
 
     /**
+     * Used to allow errors to be displayed using a front-end template
+     */
+    private bool $suppressAdminErrorContext = false;
+
+    /**
      * Assign themes to use for cms
      *
      * @config
@@ -660,6 +665,7 @@ class LeftAndMain extends Controller implements PermissionProvider
                 ),
             ];
 
+            $this->suppressAdminErrorContext = true;
             Security::permissionFailure($this, $messageSet);
             return;
         }
@@ -781,7 +787,8 @@ class LeftAndMain extends Controller implements PermissionProvider
 
     public function afterHandleRequest()
     {
-        if ($this->response->isError()
+        if (!$this->suppressAdminErrorContext
+            && $this->response->isError()
             && !$this->request->isAjax()
             && $this->response->getHeader('Content-Type') !== 'application/json'
         ) {


### PR DESCRIPTION
Proposed solution for #1443, haven’t run Behat tests locally so this may fail at first