### PR TITLE
DEP Revert dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "4.13.x-dev",
-        "silverstripe/versioned": "1.13.x-dev",
+        "silverstripe/framework": "^4.10",
+        "silverstripe/versioned": "^1@dev",
         "silverstripe/vendor-plugin": "^1.0",
         "php": "^7.4 || ^8.0"
     },


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/32

Fixes https://github.com/silverstripe/silverstripe-asset-admin/actions/runs/4495359414/jobs/7908901217

Reverting back to how it was pre 4.13 release - https://github.com/silverstripe/silverstripe-admin/commit/dceb3e8e9e4e17132f957a4d142020319711be23

Have created new issue to investigate why cow changed deps for admin https://github.com/silverstripe/.github/issues/33