### PR TITLE
MNT Update invalid translations

### DIFF
--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -2032,10 +2032,10 @@ class LeftAndMain extends Controller implements PermissionProvider
             }
             $title = LeftAndMain::menu_title($class);
             $perms[$code] = [
+                // Item in permission selection identifying the admin section. Example: Access to 'Files & Images'
                 'name' => _t(
                     CMSMain::class . '.ACCESS',
                     "Access to '{title}' section",
-                    "Item in permission selection identifying the admin section. Example: Access to 'Files & Images'",
                     ['title' => $title]
                 ),
                 'category' => _t(Permission::class . '.CMS_ACCESS_CATEGORY', 'CMS Access')

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,6 +1,4 @@
 en:
-  LeftAndMain:
-    'php.Access to ''{title}'' section': 'Item in permission selection identifying the admin section. Example: Access to ''Files & Images'''
   SilverStripe\Admin\CMSProfileController:
     CANTEDIT: 'You don''t have permission to do that'
     MENUTITLE: 'My Profile'

--- a/lang/eo.yml
+++ b/lang/eo.yml
@@ -105,5 +105,3 @@ eo:
     MemberListCaution: 'Averto: forigi membrojn el ĉi tiu listo forigos ilin ankaŭ el ĉiuj grupoj kaj la datumbazo.'
     TABROLES: Roloj
     Users: Uzantoj
-  LeftAndMain:
-    'php.Access to ''{title}'' section': 'Elemento en permesa elekto identigas la administran sekcion. Ekzemple: Aliro al ''Dosieroj kaj bildoj'''


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10797

There are no new translation keys after running i18nTextCollector because CMSMain lives in the cms module and there's already a relevant key there in en.yml