### PR TITLE
Make security admin more easily extensible

### DIFF
--- a/code/SecurityAdmin.php
+++ b/code/SecurityAdmin.php
@@ -128,11 +128,16 @@ class SecurityAdmin extends ModelAdmin implements PermissionProvider
         }
         /** @var GridFieldImportButton $importButton */
         $importButton = $config->getComponentByType(GridFieldImportButton::class);
-        $modalTitle = match ($this->modelClass) {
-            Member::class => _t(__CLASS__ . '.IMPORTUSERS', 'Import users'),
-            Group::class => _t(__CLASS__ . '.IMPORTGROUPS', 'Import groups'),
-        };
-        $importButton->setModalTitle($modalTitle);
+        if ($importButton) {
+            $modalTitle = match ($this->modelClass) {
+                Member::class => _t(__CLASS__ . '.IMPORTUSERS', 'Import users'),
+                Group::class => _t(__CLASS__ . '.IMPORTGROUPS', 'Import groups'),
+                default => null,
+            };
+            if ($modalTitle !== null) {
+                $importButton->setModalTitle($modalTitle);
+            }
+        }
         return $config;
     }
 


### PR DESCRIPTION
- fix error if import button is missing
- fix unhandled match case if model class is not member or group

ran into this issue while trying to add a couple of tabs to the security admin