### PR TITLE
PHP 8.2 compatibility fix

### DIFF
--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -62,6 +62,7 @@ use SilverStripe\View\SSViewer;
  * This is essentially an abstract class which should be subclassed.
  * See {@link CMSMain} for a good example.
  */
+#[\AllowDynamicProperties]
 class LeftAndMain extends Controller implements PermissionProvider
 {
 


### PR DESCRIPTION
Currently silverstripe-admin in version 4 triggers a lot of deprecation errors, because of setting dynamic class properties. This can be easily fixed by declaring these properties on the classes, and should have no impact on the code otherwise.

The reason for fixing this is to be able to fix deprecation errors with PHP 8.2 in other Silverstripe modules without these errors getting buried in all the deprecation errors from silverstripe-admin, not to have version 4 of silverstripe-admin officially support PHP 8.2.