### PR TITLE
Revert "ENH Make CMSProfileController use required_permission_codes"

### DIFF
--- a/code/CMSProfileController.php
+++ b/code/CMSProfileController.php
@@ -18,7 +18,7 @@ class CMSProfileController extends LeftAndMain
 
     private static $menu_title = 'My Profile';
 
-    private static $required_permission_codes = 'CMS_ACCESS';
+    private static $required_permission_codes = false;
 
     private static $tree_class = Member::class;
 
@@ -59,10 +59,8 @@ class CMSProfileController extends LeftAndMain
 
     public function canView($member = null)
     {
-        $currentUser = Security::getCurrentUser();
-
         if (!$member && $member !== false) {
-            $member = $currentUser;
+            $member = Security::getCurrentUser();
         }
 
         // cms menus only for logged-in members
@@ -70,8 +68,14 @@ class CMSProfileController extends LeftAndMain
             return false;
         }
 
-        // Check they are trying to edit themselves and they have permissions
-        return $member->ID === $currentUser->ID && parent::canView($member);
+        // Check they can access the CMS and that they are trying to edit themselves
+        if (Permission::checkMember($member, "CMS_ACCESS")
+            && $member->ID === Security::getCurrentUser()->ID
+        ) {
+            return true;
+        }
+
+        return false;
     }
 
     public function save(array $data, Form $form): HTTPResponse


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/99

Reverting https://github.com/silverstripe/silverstripe-admin/pull/1027

This caused the following failures in https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/5892574918/job/15998642199 (recipe-cms builds)

1) SilverStripe\Admin\Tests\CMSProfileControllerTest::testMemberEditsOwnProfile
2) SilverStripe\Admin\Tests\LeftAndMainTest::testCanView

I didn't investigate it too deeply, though seems that the reason is that Permission::checkMember() will (I think) count any permission code that starts with `CMS_ACCESS_` e.g. `CMS_ACCESS_CMSMain` as `CMS_ACCESS`, whereas as I'm assuming `required_permission_codes` does not?