### PR TITLE
[CVE-2023-49783] Opt in to permission checks in bulk loaders

### DIFF
--- a/code/GroupImportForm.php
+++ b/code/GroupImportForm.php
@@ -89,6 +89,7 @@ class GroupImportForm extends Form
     public function doImport($data, $form)
     {
         $loader = new GroupCsvBulkLoader();
+        $loader->setCheckPermissions(true);
 
         // load file
         $result = $loader->load($data['CsvFile']['tmp_name']);

--- a/code/MemberImportForm.php
+++ b/code/MemberImportForm.php
@@ -93,6 +93,7 @@ class MemberImportForm extends Form
     public function doImport($data, $form)
     {
         $loader = new MemberCsvBulkLoader();
+        $loader->setCheckPermissions(true);
 
         // optionally set group relation
         if ($this->group) {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^4.10",
+        "silverstripe/framework": "^4.13.39",
         "silverstripe/versioned": "^1@dev",
         "silverstripe/vendor-plugin": "^1.0",
         "php": "^7.4 || ^8.0"

--- a/tests/behat/features/files/import-company-create.csv
+++ b/tests/behat/features/files/import-company-create.csv
@@ -1,0 +1,2 @@
+Name,Category,Revenue,CEO
+"New Company",Retail,123,"New person"

--- a/tests/behat/features/files/import-company-delete.csv
+++ b/tests/behat/features/files/import-company-delete.csv
@@ -1,0 +1,1 @@
+ID,Name,Category,Revenue,CEO

--- a/tests/behat/features/files/import-company-edit.csv
+++ b/tests/behat/features/files/import-company-edit.csv
@@ -1,0 +1,2 @@
+ID,Name,Category,Revenue,CEO
+1,"Some other company",Retail,123,"some person"

--- a/tests/behat/features/gridfield-import.feature
+++ b/tests/behat/features/gridfield-import.feature
@@ -1,0 +1,83 @@
+Feature: Import in GridField
+  As a site owner
+  I want confidence that only users with permission can import records
+  So that I can sleep at night
+
+  Background:
+    Given the "Company" "Walmart" with "Category"="Retail"
+    And I am logged in with "ADMIN" permissions
+
+  Scenario: I can create new records via the import form
+    When I go to "/admin/test"
+    Then I should see 1 ".col-Name" elements
+    And I press the "Import CSV" button
+    Then I should see the "#Form_ImportForm" element
+    When I attach the file "import-company-create.csv" to the "_CsvFile" field
+    And I press the "Import from CSV" button
+    Then I should see "Imported 1 record" in the "#Form_ImportForm" element
+    And I should see 2 ".col-Name" elements
+
+  Scenario: I cannot create new records without permission
+    Given I add an extension "SilverStripe\Admin\Tests\Behat\Context\Extension\CannotCreateExtension" to the "SilverStripe\FrameworkTest\Model\Company" class
+    When I go to "/admin/test"
+    And I press the "Import CSV" button
+    Then I should see the "#Form_ImportForm" element
+    When I attach the file "import-company-create.csv" to the "_CsvFile" field
+    And I press the "Import from CSV" button
+    Then I should see "Not allowed to create 'Company' records" in the "#Form_ImportForm" element
+    And I should see 1 ".col-Name" elements
+    And I should see "Walmart" in the ".col-Name" element
+
+  Scenario: I can edit existing records via the import form
+    # To edit, we have to rely on IDs - so start by validating that a record with that ID exists at all.
+    When I go to "/admin/test/SilverStripe-FrameworkTest-Model-Company/EditForm/field/SilverStripe-FrameworkTest-Model-Company/item/1"
+    # Check we are viewing a record (we don't know or care what it's called)
+    Then I should see "Main" in the "div.cms-content-header-tabs" element
+    # Check we didn't get a not found error
+    And I should not see "Not Found"
+    When I go to "/admin/test"
+    And I press the "Import CSV" button
+    Then I should see the "#Form_ImportForm" element
+    When I attach the file "import-company-edit.csv" to the "_CsvFile" field
+    And I press the "Import from CSV" button
+    Then I should see "Updated 1 record" in the "#Form_ImportForm" element
+    And I should see 1 ".col-Name" elements
+    And I should not see "Walmart" in the ".col-Name" element
+    And I should see "Some other company" in the ".col-Name" element
+
+  Scenario: I cannot edit existing records without permission
+    Given I add an extension "SilverStripe\Admin\Tests\Behat\Context\Extension\CannotEditExtension" to the "SilverStripe\FrameworkTest\Model\Company" class
+    # We can't check if the record exists here because we don't have permission! But if it doesn't, this test will fail anyway.
+    When I go to "/admin/test"
+    And I press the "Import CSV" button
+    Then I should see the "#Form_ImportForm" element
+    When I attach the file "import-company-edit.csv" to the "_CsvFile" field
+    And I press the "Import from CSV" button
+    Then I should see "Not allowed to edit 'Company' records" in the "#Form_ImportForm" element
+    And I should see 1 ".col-Name" elements
+    And I should see "Walmart" in the ".col-Name" element
+    And I should not see "Some other company" in the ".col-Name" element
+
+  Scenario: I can delete records via the import form
+    When I go to "/admin/test"
+    And I press the "Import CSV" button
+    Then I should see the "#Form_ImportForm" element
+    When I attach the file "import-company-delete.csv" to the "_CsvFile" field
+    And I check "Replace data"
+    And I press the "Import from CSV" button
+    Then I should see "Nothing to import" in the "#Form_ImportForm" element
+    And I should see "No items found" in the ".ss-gridfield-items" element
+    And I should not see the ".col-Name" element
+
+  Scenario: I cannot delete records without permission
+    Given I add an extension "SilverStripe\Admin\Tests\Behat\Context\Extension\CannotDeleteExtension" to the "SilverStripe\FrameworkTest\Model\Company" class
+    When I go to "/admin/test"
+    And I press the "Import CSV" button
+    Then I should see the "#Form_ImportForm" element
+    When I attach the file "import-company-delete.csv" to the "_CsvFile" field
+    And I check "Replace data"
+    And I press the "Import from CSV" button
+    Then I should see "Not allowed to delete 'Company' records" in the "#Form_ImportForm" element
+    And I should not see "No items found" in the ".ss-gridfield-items" element
+    And I should see 1 ".col-Name" elements
+    And I should see "Walmart" in the ".col-Name" element

--- a/tests/behat/src/Extension/CannotCreateExtension.php
+++ b/tests/behat/src/Extension/CannotCreateExtension.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\Admin\Tests\Behat\Context\Extension;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+
+class CannotCreateExtension extends Extension implements TestOnly
+{
+    public function canCreate()
+    {
+        return false;
+    }
+}

--- a/tests/behat/src/Extension/CannotDeleteExtension.php
+++ b/tests/behat/src/Extension/CannotDeleteExtension.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\Admin\Tests\Behat\Context\Extension;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+
+class CannotDeleteExtension extends Extension implements TestOnly
+{
+    public function canDelete()
+    {
+        return false;
+    }
+}

--- a/tests/behat/src/Extension/CannotEditExtension.php
+++ b/tests/behat/src/Extension/CannotEditExtension.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\Admin\Tests\Behat\Context\Extension;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+
+class CannotEditExtension extends Extension implements TestOnly
+{
+    public function canEdit()
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
This should match https://github.com/silverstripe-security/silverstripe-admin/pull/17 exactly, except for the changed patch number in the framework constraint.

CI has already passed in the security repository. Any CI failures that are present there are expected and accounted for. This can be merged safely without waiting for CI to run again. CI will run after merging anyway, and is a safeguard prior to patching.

## Issue
- https://github.com/silverstripeltd/product-issues/issues/832
- https://github.com/silverstripe-security/security-issues/issues/177