### PR TITLE
FIX Use valid class for model importers

### DIFF
--- a/code/ModelAdmin.php
+++ b/code/ModelAdmin.php
@@ -610,10 +610,10 @@ abstract class ModelAdmin extends LeftAndMain
     public function getModelImporters()
     {
         $importerClasses = $this->config()->get('model_importers');
+        $models = $this->getManagedModels();
 
         // fallback to all defined models if not explicitly defined
         if (is_null($importerClasses)) {
-            $models = $this->getManagedModels();
             foreach ($models as $modelName => $options) {
                 $importerClasses[$modelName] = 'SilverStripe\\Dev\\CsvBulkLoader';
             }
@@ -621,6 +621,9 @@ abstract class ModelAdmin extends LeftAndMain
 
         $importers = [];
         foreach ($importerClasses as $modelClass => $importerClass) {
+            if (isset($models[$modelClass])) {
+                $modelClass = $models[$modelClass]['dataClass'];
+            }
             $importer = new $importerClass($modelClass);
             if (ClassInfo::hasMethod($importer, 'setCheckPermissions')) {
                 $importer->setCheckPermissions(true);

--- a/tests/php/ModelAdminTest.php
+++ b/tests/php/ModelAdminTest.php
@@ -164,6 +164,15 @@ class ModelAdminTest extends FunctionalTest
         );
     }
 
+    public function testGetModelImporters()
+    {
+        $admin = new ModelAdminTest\MultiModelAdmin();
+        $importers = $admin->getModelImporters();
+        $this->assertCount(2, $importers);
+        $this->assertArrayHasKey(Contact::class, $importers);
+        $this->assertArrayHasKey(Player::class, $importers);
+    }
+
     public function testGetManagedModels()
     {
         $admin = new ModelAdminTest\MultiModelAdmin();


### PR DESCRIPTION
Basically the same fix as https://github.com/silverstripe/silverstripe-admin/pull/1657, which I should have realised at the time would affect the 1.x line as well.

## Issue
- https://github.com/silverstripe/silverstripe-admin/issues/1668