### PR TITLE
FIX Set the CSV importer based on the tab, not the model

### DIFF
--- a/code/ModelAdmin.php
+++ b/code/ModelAdmin.php
@@ -621,6 +621,7 @@ abstract class ModelAdmin extends LeftAndMain
 
         $importers = [];
         foreach ($importerClasses as $modelClass => $importerClass) {
+            $tab = $modelClass;
             if (isset($models[$modelClass])) {
                 $modelClass = $models[$modelClass]['dataClass'];
             }
@@ -628,7 +629,7 @@ abstract class ModelAdmin extends LeftAndMain
             if (ClassInfo::hasMethod($importer, 'setCheckPermissions')) {
                 $importer->setCheckPermissions(true);
             }
-            $importers[$modelClass] = $importer;
+            $importers[$tab] = $importer;
         }
 
         return $importers;

--- a/tests/php/ModelAdminTest.php
+++ b/tests/php/ModelAdminTest.php
@@ -168,9 +168,11 @@ class ModelAdminTest extends FunctionalTest
     {
         $admin = new ModelAdminTest\MultiModelAdmin();
         $importers = $admin->getModelImporters();
-        $this->assertCount(2, $importers);
+        $this->assertCount(4, $importers);
         $this->assertArrayHasKey(Contact::class, $importers);
         $this->assertArrayHasKey(Player::class, $importers);
+        $this->assertArrayHasKey('Player', $importers);
+        $this->assertArrayHasKey('cricket-players', $importers);
     }
 
     public function testGetManagedModels()


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Confirmed the bug affects CMS 4 as well, so fixing it there.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
Copy the `SecurityAdmin` from CMS 5 and plonk it into CMS 4, then try to import a member. If you add it as a separate class you'll want to set a different `url_segment` and `menu_title` so you know what one you're looking at. Note that there's syntax in there that needs to run on PHP 8.1 - but that doesn't affect the actual code fix which as per CI is compatible with 7.4

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-admin/issues/1672

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] CI is green
