### PR TITLE
NEW Add `extra_requirements_i18n` config to `LeftAndMain`

### DIFF
--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -230,6 +230,20 @@ class LeftAndMain extends Controller implements PermissionProvider
     private static $extra_requirements_javascript = [];
 
     /**
+     * Register additional i18n requirements through the {@link Requirements} class.
+     *
+     * YAML configuration example:
+     * <code>
+     * LeftAndMain:
+     *   extra_requirements_i18n:
+     *     - mysite/client/lang
+     *     'myorg/mymodule:client/lang': true
+     * </code>
+     * @var array See {@link extra_requirements_javascript}
+     */
+    private static array $extra_requirements_i18n = [];
+
+    /**
      * YAML configuration example:
      * <code>
      * LeftAndMain:
@@ -720,6 +734,17 @@ class LeftAndMain extends Controller implements PermissionProvider
                 }
 
                 Requirements::javascript($file, $config);
+            }
+        }
+
+        $extraI18n = $this->config()->get('extra_requirements_i18n');
+        if ($extraI18n) {
+            foreach ($extraI18n as $dir => $return) {
+                if (is_numeric($dir)) {
+                    $dir = $return;
+                    $return = false;
+                }
+                Requirements::add_i18n_javascript($dir, $return);
             }
         }
 


### PR DESCRIPTION
Required for https://github.com/silverstripe/silverstripe-linkfield/pull/216

There's already config to add javascript and css so we ought to provide this for `i18n` as well.

We have other modules which also have an entire extension just for adding i18n, javascript, and css. Technically deleting those extensions would be a breaking API change according to our [definition of public API](https://docs.silverstripe.org/en/5/project_governance/public_api/) but in an upcoming major release we should delete them and just use config. I'll create a card for that.

## Issue
- https://github.com/silverstripe/silverstripe-linkfield/issues/78