### PR TITLE
FIX Correctly validate emails in WYSIWYG links

### DIFF
--- a/code/Forms/EditorEmailLinkFormFactory.php
+++ b/code/Forms/EditorEmailLinkFormFactory.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Admin\Forms;
 
+use SilverStripe\Forms\EmailField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\RequiredFields;
@@ -11,7 +12,7 @@ class EditorEmailLinkFormFactory extends LinkFormFactory
     protected function getFormFields($controller, $name, $context)
     {
         $fields = FieldList::create([
-            TextField::create(
+            EmailField::create(
                 'Link',
                 _t(__CLASS__.'.EMAIL', 'Email address')
             ),


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Ensure the correct `EmailField` form field is used for entering email addresses in WYSIWYG links. This provides appropriate validation errors when incorrect values are entered.

Note I haven't added behat for this because shockingly there is no behat *at all* in this module for WYSIWYG links - so adding them in this PR for this fix is a bit overkill.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
In any WYSIWYG field, try to add an email address link with an invalid email address. You should be given an appropriate validation error within the modal form.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-admin/issues/1707

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [ ] CI is green
