### PR TITLE
ENH Remove duplicated default settings from cms TinyMCE config

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -24,24 +24,9 @@ $editorConfig
         'friendly_name' => 'Default CMS',
         'priority' => '50',
         'skin' => 'silverstripe',
-        'body_class' => 'typography',
         'contextmenu' => "searchreplace | sslink anchor ssmedia ssembed inserttable | cell row column deletetable",
         'use_native_selects' => false,
-        'valid_elements' => "@[id|class|style|title],a[id|rel|rev|dir|tabindex|accesskey|type|name|href|target|title"
-            . "|class],-strong/-b[class],-em/-i[class],-strike[class],-u[class],#p[id|dir|class|align|style],-ol[class],"
-            . "-ul[class],-li[class],br,img[id|dir|longdesc|usemap|class|src|border|alt=|title|width|height|align|data*],"
-            . "-sub[class],-sup[class],-blockquote[dir|class],-cite[dir|class|id|title],"
-            . "-table[cellspacing|cellpadding|width|height|class|align|summary|dir|id|style],"
-            . "-tr[id|dir|class|rowspan|width|height|align|valign|bgcolor|background|bordercolor|style],"
-            . "tbody[id|class|style],thead[id|class|style],tfoot[id|class|style],"
-            . "#td[id|dir|class|colspan|rowspan|width|height|align|valign|scope|style],"
-            . "-th[id|dir|class|colspan|rowspan|width|height|align|valign|scope|style],caption[id|dir|class],"
-            . "-div[id|dir|class|align|style],-span[class|align|style],-pre[class|align],address[class|align],"
-            . "-h1[id|dir|class|align|style],-h2[id|dir|class|align|style],-h3[id|dir|class|align|style],"
-            . "-h4[id|dir|class|align|style],-h5[id|dir|class|align|style],-h6[id|dir|class|align|style],hr[class],"
-            . "dd[id|class|title|dir],dl[id|class|title|dir],dt[id|class|title|dir]",
-        'extended_valid_elements' => "img[class|src|alt|title|hspace|vspace|width|height|align|name"
-            . "|usemap|data*],iframe[src|name|width|height|align|frameborder|marginwidth|marginheight|scrolling],"
+        'extended_valid_elements' => "iframe[src|name|width|height|align|frameborder|marginwidth|marginheight|scrolling],"
             . "object[width|height|data|type],param[name|value],map[class|name|id],area[shape|coords|href|target|alt]"
     ]);
 // enable ability to insert anchors

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5.1.11",
+        "silverstripe/framework": "^5.3",
         "silverstripe/versioned": "^2",
         "silverstripe/vendor-plugin": "^2"
     },


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Requires https://github.com/silverstripe/silverstripe-framework/pull/11201
Removes the duplication of default settings for the cms TinyMCE config instance. This does two things:
1. Removes duplication, so if we make a change we only have to change it once
2. Ensures changes to the defaults will apply to the cms config, which is appropriate.

Note that this config has some `extended_valid_elements` defined - I've opted to not include that in the default set, because these elements aren't things you're likely to want in most of your WSIWYG fields. In a future major release we'll probably be removing these from the cms config as well.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-framework/issues/11141