### PR TITLE
FIX return 404 instead of 500 for invalid model class, fixes #570

### DIFF
--- a/code/ModelAdmin.php
+++ b/code/ModelAdmin.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Admin;
 
 use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
@@ -162,7 +163,8 @@ abstract class ModelAdmin extends LeftAndMain
             $this->modelTab = $this->unsanitiseClassName($this->modelTab);
 
             if (!$this->isManagedModel($this->modelTab)) {
-                throw new \RuntimeException(sprintf('ModelAdmin::init(): Invalid Model class %s', $this->modelTab));
+                Injector::inst()->get(LoggerInterface::class)->error(sprintf('ModelAdmin::init(): Invalid Model class %s', $this->modelTab));
+                return $this->httpError(404, 'Page not found');
             }
         }
 


### PR DESCRIPTION
## Description

When a ModelAdmin is called with a model that doesn’t exist, the fact that it doesn’t exist is exposed in a 500 error if the site is in dev.
 
Affected: silverstripe/silverstripe-admin 1 and 2 (Silverstripe 4 and 5)
 
In the init() method of ModelAdmin (https://github.com/silverstripe/silverstripe-admin/blob/2/code/ModelAdmin.php#L165) a RuntimeException is thrown including the class information. This is also the case when there is no user logged into the CMS. 

This is the case for v1 and v2 of this module!

## Issues
- #570

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
