### PR TITLE
MNT Fix behat failure

### DIFF
--- a/tests/behat/features/multitab-validation.feature
+++ b/tests/behat/features/multitab-validation.feature
@@ -26,6 +26,12 @@ Feature: Multi-tab page validation icons
     Then I should not see an invalid tab icon on the "Second" tab
     Then I should not see an invalid tab icon on the "Third" tab
     Then I should see an invalid tab icon on the "Fourth" tab
+    And I fill in "Third tab first field" with "abc@example.com"
+    When I press the "Save" button
+    Then I can see the form validation error message
+    Then I should not see an invalid tab icon on the "Second" tab
+    Then I should not see an invalid tab icon on the "Third" tab
+    Then I should see an invalid tab icon on the "Fourth" tab
     When I click on the "#tab-Root_Fourth" element
     And I fill in "Fourth tab first field" with "def"
     When I press the "Save" button


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-admin/actions/runs/9456664685/job/26049017215

> Scenario: I can see tab validation icons on multi-tab pages     # tests/behat/features/multitab-validation.feature:12
> Then I can see the form validation error message              # SilverStripe\Admin\Tests\Behat\Context\AdminContext::iCanSeeTheFormValidationErrorMessage()
>
> Element #Form_EditForm_error not found
> Failed asserting that false is true.

The failure was caused by https://github.com/silverstripe/silverstripe-frameworktest/pull/180 which was for a change in admin on branch `2`: https://github.com/silverstripe/silverstripe-admin/pull/1751

This PR updates the behat tests for `2.2` to account for the change to frameworktest.

## Issue
- https://github.com/silverstripe/.github/issues/266