### PR TITLE
MNT Add behat feature to numbered CI job

### DIFF
--- a/tests/behat/features/gridfield-render-html.feature
+++ b/tests/behat/features/gridfield-render-html.feature
@@ -1,4 +1,4 @@
-@retry
+@retry @job1
 Feature: Render HTML in GridField
   As a developer
   I want to have the ability to render HTML in a GridField column


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-admin/actions/runs/10033678651/job/27727146093

> At least one .feature files missing a `@job[0-9]+ tag`

## Issue
- https://github.com/silverstripe/.github/issues/285