### PR TITLE
DEP Conflict with incompatible version of elemental

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,9 @@
         "silverstripe/standards": "^1",
         "phpstan/extension-installer": "^1.3"
     },
+    "conflict": {
+        "dnadesign/silverstripe-elemental": "<5.3.0"
+    },
     "extra": {
         "expose": [
             "client/dist",


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-graphql/actions/runs/10086656540/job/28024281063
> No toast container found with text: Validation error

Graphql branch `5` uses the `^5` constraint to pull in elemental, which gets `5.2.*` right now because those are the stable tags.
It turns out elemental `5.2` and admin `2.3` are incompatible with one another. Adding this `conflict` to admin results in getting the `5.x-dev` constraint for elemental instead, which will pass happily.

An alternative would be to change the constraint in graphql from `^5` to `5.x-dev` but then when we release 5.3 we'll still have the `5.x-dev` constraint so we'd have the opposite problem, where the next minor is being pulled in when testing against graphql 5.3.

## issue
- https://github.com/silverstripe/.github/issues/287