### PR TITLE
Fix CSS so TinyMCE sslink popup windows show over fullscreen

### DIFF
--- a/client/src/styles/_bootstrap-variables.scss
+++ b/client/src/styles/_bootstrap-variables.scss
@@ -528,13 +528,13 @@ $dropdown-item-padding-x:        1.3rem !default;
 // Warning: Avoid customizing these values. They're used for a bird's eye view
 // of components dependent on the z-axis and are designed to all work together.
 
-//$zindex-dropdown:           1000 !default;
-//$zindex-sticky:             1020 !default;
-//$zindex-fixed:              1030 !default;
-//$zindex-modal-backdrop:     1040 !default;
-//$zindex-modal:              1050 !default;
-//$zindex-popover:            1060 !default;
-//$zindex-tooltip:            1070 !default;
+//$zindex-dropdown:           1200 !default;
+//$zindex-sticky:             1220 !default;
+//$zindex-fixed:              1230 !default;
+//$zindex-modal-backdrop:     1240 !default;
+//$zindex-modal:              1250 !default;
+//$zindex-popover:            1260 !default;
+//$zindex-tooltip:            1270 !default;
 
 // Navs
 

--- a/client/src/styles/_variables.scss
+++ b/client/src/styles/_variables.scss
@@ -91,9 +91,9 @@ $input-padding-y-lg: .75rem;
 // Warning: Avoid customizing these values. They're used for a bird's eye view
 // of components dependent on the z-axis and are designed to all work together.
 
-$zindex-popover: 1060;
-$zindex-modal-bg: 1040;
-$zindex-modal: 1050;
+$zindex-popover: 1260;
+$zindex-modal-bg: 1240;
+$zindex-modal: 1250;
 $zindex-cms-content-header: 60;
 $zindex-cms-content-actions: 79;
 $zindex-menu: $zindex-cms-content-actions + 1;


### PR DESCRIPTION
## Description
When using TinyMCE in CMS 5.2, the editor's full screen mode hides the pop-up windows which allow users to configure links. This applies to all types of links (internal, external, file, anchor, email, phone).

This appears to be due to the TinyMCE fullscreen mode having a `z-index` of 1200, whereas the popup windows are at 1050. When I manually change this in chrome dev tools, the popups appear over the full screen as they should.

## Manual testing steps
1. Go to any TinyMCE editor field which has buttons for full screen and for SSLink
2. Open full screen mode
3. Select some text and press the SSLink button, and select any option from the dropdown field
4. Observe that no popup appears
5. Close full screen mode; observe that the popup for editing that link type is now visible.


## Issues

* #1815 

## Pull request checklist
- [ ] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
