### PR TITLE
NEW AdminController as superclass for /admin/* routed controllers

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -31,5 +31,3 @@ $editorConfig
     ]);
 // enable ability to insert anchors
 $editorConfig->insertButtonsAfter('sslink', 'anchor');
-
-CMSMenu::remove_menu_class(CMSProfileController::class);

--- a/code/AdminController.php
+++ b/code/AdminController.php
@@ -1,0 +1,359 @@
+<?php
+
+namespace SilverStripe\Admin;
+
+use BadMethodCallException;
+use InvalidArgumentException;
+use SilverStripe\Control\ContentNegotiator;
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Control\HTTPResponse_Exception;
+use SilverStripe\Control\Middleware\HTTPCacheControlMiddleware;
+use SilverStripe\Forms\HTMLEditor\HTMLEditorConfig;
+use SilverStripe\i18n\i18n;
+use SilverStripe\Security\Permission;
+use SilverStripe\Security\Security;
+use SilverStripe\Versioned\Versioned;
+use SilverStripe\View\SSViewer;
+
+/**
+ * The base class for all controllers routed using the /admin/* route.
+ *
+ * This class is automatically routed via the AdminRootController.
+ * It's responsible for ensuring permissions are respected.
+ */
+abstract class AdminController extends Controller
+{
+    /**
+     * The current url segment attached to the controller
+     */
+    private static ?string $url_segment = null;
+
+    /**
+     * Used by {@link AdminRootController} to augment Director route rules for subclasses of AdminController
+     */
+    private static string $url_rule = '/$Action/$ID/$OtherID';
+
+    /**
+     * Priority order for routing rules. If two controllers match a given request, the one with a higher
+     * priority will handle the request.
+     */
+    private static int $url_priority = 50;
+
+    /**
+     * Codes which are required from the current user to view this controller.
+     *
+     * If multiple codes are provided, all of them are required.
+     * All CMS controllers require "CMS_ACCESS_LeftAndMain" as a baseline check,
+     * and fall back to "CMS_ACCESS_<class>" if no permissions are defined here.
+     * See {@link canView()} for more details on permission checks.
+     */
+    private static string|array $required_permission_codes = [];
+
+    /**
+     * The configuration passed to the supporting JS for each CMS section includes a 'name' key
+     * that by default matches the FQCN of the current class. This setting allows you to change
+     * the key if necessary (for example, if you are overloading CMSMain or another core class
+     * and want to keep the core JS - which depends on the core class names - functioning, you
+     * would need to set this to the FQCN of the class you are overloading).
+     *
+     * See getClientConfig()
+     */
+    private static ?string $section_name = null;
+
+    /**
+     * Get list of required permissions for accessing this controller.
+     * If false, no permission is required.
+     */
+    public static function getRequiredPermissions(): array|string|false
+    {
+        if (static::class === AdminController::class) {
+            throw new BadMethodCallException('getRequiredPermissions should be called on a subclass');
+        }
+        // If the user is accessing LeftAndMain directly, only generic permissions are required.
+        if (static::class === LeftAndMain::class) {
+            return 'CMS_ACCESS';
+        }
+        $codes = static::config()->get('required_permission_codes');
+        // allow explicit FALSE to disable subclass check
+        if ($codes === false) {
+            return false;
+        }
+        if ($codes) {
+            return $codes;
+        }
+        // Fallback if no explicit permission was declared
+        return 'CMS_ACCESS_' . static::class;
+    }
+
+    public function canView($member = null)
+    {
+        if (!$member && $member !== false) {
+            $member = Security::getCurrentUser();
+        }
+
+        // don't allow unauthenticated users
+        if (!$member) {
+            return false;
+        }
+
+        // alternative extended checks
+        if ($this->hasMethod('alternateAccessCheck')) {
+            $alternateAllowed = $this->alternateAccessCheck($member);
+            if ($alternateAllowed === false) {
+                return false;
+            }
+        }
+
+        // Check for "Access to all CMS sections" permission
+        if (Permission::checkMember($member, 'CMS_ACCESS_LeftAndMain')) {
+            return true;
+        }
+
+        // Check for permission to access this specific controller
+        $codes = static::getRequiredPermissions();
+        // allow explicit FALSE to disable subclass check
+        if ($codes === false) {
+            return true;
+        }
+        foreach ((array) $codes as $code) {
+            if (!Permission::checkMember($member, $code)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function Link($action = null)
+    {
+        // LeftAndMain methods have a top-level uri access
+        if (static::class === LeftAndMain::class) {
+            $segment = '';
+        } else {
+            // Get url_segment
+            $segment = static::config()->get('url_segment');
+            if (!$segment) {
+                throw new BadMethodCallException(
+                    sprintf('AdminController subclasses (%s) must have url_segment', static::class)
+                );
+            }
+        }
+
+        $link = Controller::join_links(
+            AdminRootController::admin_url(),
+            $segment,
+            "$action"
+        );
+        $this->extend('updateLink', $link);
+        return $link;
+    }
+
+    /**
+     * Overloaded redirection logic to trigger a fake redirect on ajax requests.
+     * While this violates HTTP principles, its the only way to work around the
+     * fact that browsers handle HTTP redirects opaquely, no intervention via JS is possible.
+     * In isolation, that's not a problem - but combined with history.pushState()
+     * it means we would request the same redirection URL twice if we want to update the URL as well.
+     * See LeftAndMain.js for the required jQuery ajaxComplete handlers.
+     */
+    public function redirect(string $url, int $code = 302): HTTPResponse
+    {
+        if ($this->getRequest()->isAjax()) {
+            $response = $this->getResponse();
+            $response->addHeader('X-ControllerURL', $url);
+            if ($this->getRequest()->getHeader('X-Pjax') && !$response->getHeader('X-Pjax')) {
+                $response->addHeader('X-Pjax', $this->getRequest()->getHeader('X-Pjax'));
+            }
+            $newResponse = new LeftAndMain_HTTPResponse(
+                $response->getBody(),
+                $response->getStatusCode(),
+                $response->getStatusDescription()
+            );
+            foreach ($response->getHeaders() as $k => $v) {
+                $newResponse->addHeader($k, $v);
+            }
+            $newResponse->setIsFinished(true);
+            $this->setResponse($newResponse);
+            // Actual response will be re-requested by client
+            return $newResponse;
+        } else {
+            return parent::redirect($url, $code);
+        }
+    }
+
+    /**
+     * Returns configuration required by the client app
+     */
+    public function getClientConfig(): array
+    {
+        // Allows the section name to be overridden in config
+        $name = static::config()->get('section_name') ?: static::class;
+        // Trim leading/trailing slash to make it easier to concatenate URL
+        // and use in routing definitions.
+        $url = trim($this->Link(), '/');
+        $clientConfig = [
+            'name' => $name,
+            'url' => $url,
+            'reactRoutePath' => preg_replace('/^' . preg_quote(AdminRootController::admin_url(), '/') . '/', '', $url),
+        ];
+        $this->extend('updateClientConfig', $clientConfig);
+        return $clientConfig;
+    }
+
+    protected function init()
+    {
+        parent::init();
+
+        HTTPCacheControlMiddleware::singleton()->disableCache();
+
+        SSViewer::setRewriteHashLinksDefault(false);
+        ContentNegotiator::setEnabled(false);
+
+        // set language
+        $member = Security::getCurrentUser();
+        if (!empty($member->Locale)) {
+            i18n::set_locale($member->Locale);
+        }
+
+        // Don't allow access if the request hasn't finished being handled and the user can't access this controller
+        if (!$this->canView() && !$this->getResponse()->isFinished()) {
+            // Allow subclasses and extensions to redirect somewhere more appropriate
+            $this->invokeWithExtensions('onInitPermissionFailure');
+
+            // If we're redirecting away, just let that happen
+            if ($this->getResponse()->isRedirect()) {
+                return;
+            }
+
+            if (Security::getCurrentUser()) {
+                $this->getRequest()->getSession()->clear("BackURL");
+            }
+
+            // if no alternate menu items have matched, return a permission error
+            $messageSet = [
+                'default' => _t(
+                    __CLASS__ . '.PERMDEFAULT',
+                    "You must be logged in to access the administration area."
+                ),
+                'alreadyLoggedIn' => _t(
+                    __CLASS__ . '.PERMALREADY',
+                    "I'm sorry, but you can't access that part of the CMS."
+                ),
+                'logInAgain' => _t(
+                    __CLASS__ . '.PERMAGAIN',
+                    "You have been logged out of the CMS."
+                ),
+            ];
+
+            $this->suppressAdminErrorContext = true;
+            Security::permissionFailure($this, $messageSet);
+            return;
+        }
+
+        // Don't continue if there's already been a redirection request.
+        if ($this->getResponse()->isRedirect()) {
+            return;
+        }
+
+        $this->extend('onInit');
+
+        // Load the editor with original user themes before overwriting
+        // them with admin themes
+        $themes = HTMLEditorConfig::getThemes();
+        if (empty($themes)) {
+            HTMLEditorConfig::setThemes(SSViewer::get_themes());
+        }
+
+        // Assign default cms theme and replace user-specified themes
+        // This ensures any templates rendered use appropriate templates and resources
+        // instead of the front-end ones
+        SSViewer::set_themes(LeftAndMain::config()->uninherited('admin_themes'));
+
+        // Set the current reading mode
+        Versioned::set_stage(Versioned::DRAFT);
+
+        // Set default reading mode to suppress ?stage=Stage querystring params in CMS
+        Versioned::set_default_reading_mode(Versioned::get_reading_mode());
+    }
+
+    /**
+     * Get a data value from JSON in body of the POST request, ensuring it exists
+     * Will only read from the root node of the JSON body
+     */
+    protected function getPostedJsonValue(HTTPRequest $request, string $key): mixed
+    {
+        $data = json_decode($request->getBody(), true);
+        if (!array_key_exists($key, $data)) {
+            $this->jsonError(400);
+        }
+        return $data[$key];
+    }
+
+    /**
+     * Creates a successful json response
+     */
+    protected function jsonSuccess(int $statusCode, ?array $data = null): HTTPResponse
+    {
+        if ($statusCode < 200 || $statusCode >= 300) {
+            throw new InvalidArgumentException("Status code $statusCode must be between 200 and 299");
+        }
+        if (is_null($data)) {
+            $body = '';
+        } else {
+            $body = json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        }
+        return $this->getResponse()
+            ->addHeader('Content-Type', 'application/json')
+            ->setStatusCode($statusCode)
+            ->setBody($body);
+    }
+
+    /**
+     * Throw an error HTTPResponse encoded as json
+     *
+     * @throws HTTPResponse_Exception which interrupts request handling with the appropriate response
+     */
+    protected function jsonError(int $errorCode, string $errorMessage = ''): void
+    {
+        // Build error from message
+        $error = [
+            'type' => 'error',
+            'code' => $errorCode,
+        ];
+        if ($errorMessage) {
+            $error['value'] = $errorMessage;
+        } else {
+            $messageDefault = match ($errorCode) {
+                400 => 'Sorry, it seems there was something wrong with the request.',
+                401 => 'Sorry, it seems you are not authorised to access this section or object.',
+                403 => 'Sorry, it seems the action you were trying to perform is forbidden.',
+                404 => 'Sorry, it seems you were trying to access a section or object that doesn\'t exist.',
+                500 => 'Sorry, it seems there was an internal server error.',
+                503 => 'Sorry, it seems the service is temporarily unavailable.',
+                default => 'Error',
+            };
+            /** @phpstan-ignore translation.key (we need the key to be dynamic here) */
+            $error['value'] = _t(__CLASS__ . ".ErrorMessage{$errorCode}", $messageDefault);
+        }
+
+        // Support explicit error handling with status = error, or generic message handling
+        // with a message of type = error
+        $result = [
+            'status' => 'error',
+            'errors' => [$error]
+        ];
+        $response = HTTPResponse::create(json_encode($result), $errorCode)
+            ->addHeader('Content-Type', 'application/json');
+
+        // Call a handler method such as onBeforeHTTPError404
+        $this->extend("onBeforeJSONError{$errorCode}", $request, $response);
+
+        // Call a handler method such as onBeforeHTTPError, passing 404 as the first arg
+        $this->extend('onBeforeJSONError', $errorCode, $request, $response);
+
+        // Throw a new exception
+        throw new HTTPResponse_Exception($response);
+    }
+}

--- a/code/CMSProfileController.php
+++ b/code/CMSProfileController.php
@@ -22,6 +22,8 @@ class CMSProfileController extends LeftAndMain
 
     private static $tree_class = Member::class;
 
+    private static $ignore_menuitem = true;
+
     public function getEditForm($id = null, $fields = null)
     {
         $this->setCurrentPageID(Security::getCurrentUser()->ID);

--- a/code/SudoModeController.php
+++ b/code/SudoModeController.php
@@ -15,11 +15,9 @@ use SilverStripe\Security\SudoMode\SudoModeServiceInterface;
 /**
  * Responsible for checking and verifying whether sudo mode is enabled
  */
-class SudoModeController extends LeftAndMain
+class SudoModeController extends AdminController
 {
     private static string $url_segment = 'sudomode';
-
-    private static bool $ignore_menuitem = true;
 
     private static array $allowed_actions = [
         'check',
@@ -43,7 +41,7 @@ class SudoModeController extends LeftAndMain
      */
     private static bool $required_permission_codes = false;
 
-    public function getClientConfig()
+    public function getClientConfig(): array
     {
         $request = Injector::inst()->get(HTTPRequest::class);
 
@@ -91,7 +89,7 @@ class SudoModeController extends LeftAndMain
             return $this->jsonResponse([
                 'result' => false,
                 'message' => _t(__CLASS__ . '.INVALID', 'Incorrect password'),
-            ]);
+            ], 401);
         }
 
         // Activate sudo mode and return successful result

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,4 +1,12 @@
 en:
+  SilverStripe\Admin\AdminController:
+    ErrorMessage: 'Sorry, it seems there was a {errorcode} error.'
+    ErrorMessage400: 'Sorry, it seems there was something wrong with the request.'
+    ErrorMessage401: 'Sorry, it seems you are not authorised to access this section or object.'
+    ErrorMessage403: 'Sorry, it seems the action you were trying to perform is forbidden.'
+    ErrorMessage404: "Sorry, it seems you were trying to access a section or object that doesn't exist."
+    ErrorMessage500: 'Sorry, it seems there was an internal server error.'
+    ErrorMessage503: 'Sorry, it seems the service is temporarily unavailable.'
   SilverStripe\Admin\CMSProfileController:
     CANTEDIT: "You don't have permission to do that"
     MENUTITLE: 'My Profile'

--- a/tests/php/AdminControllerTest.php
+++ b/tests/php/AdminControllerTest.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace SilverStripe\Admin\Tests;
+
+use SilverStripe\Dev\FunctionalTest;
+use SilverStripe\Security\Member;
+use SilverStripe\Control\HTTPResponse_Exception;
+use ReflectionObject;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Admin\CMSProfileController;
+use SilverStripe\Admin\SecurityAdmin;
+use SilverStripe\Admin\Tests\LeftAndMainTest\DualPermissionAdminController;
+use SilverStripe\Admin\Tests\LeftAndMainTest\TestAdminController;
+
+class AdminControllerTest extends FunctionalTest
+{
+    protected static $fixture_file = 'AdminControllerTest.yml';
+
+    public static function provideCanView(): array
+    {
+        return [
+            'logged out' => [
+                'fixtureName' => null,
+                'allowed' => [],
+            ],
+            'no-access user' => [
+                'fixtureName' => 'noaccessuser',
+                'allowed' => [],
+            ],
+            'restricted CMS user' => [
+                'fixtureName' => 'securityonlyuser',
+                'allowed' => [
+                    CMSProfileController::class,
+                    SecurityAdmin::class,
+                ],
+            ],
+            'all cms sections user' => [
+                'fixtureName' => 'allcmssectionsuser',
+                'allowed' => [
+                    TestAdminController::class,
+                    DualPermissionAdminController::class,
+                    CMSProfileController::class,
+                    SecurityAdmin::class,
+                ],
+            ],
+            'admin user' => [
+                'fixtureName' => 'admin',
+                'allowed' => [
+                    TestAdminController::class,
+                    DualPermissionAdminController::class,
+                    CMSProfileController::class,
+                    SecurityAdmin::class,
+                ],
+            ],
+            'permission1 user (missing permission2)' => [
+                'fixtureName' => 'permission1user',
+                'allowed' => [],
+            ],
+            'permission2 user (missing permission1)' => [
+                'fixtureName' => 'permission2user',
+                'allowed' => [],
+            ],
+            'permission1 and 2 user user' => [
+                'fixtureName' => 'permission1and2user',
+                'allowed' => [
+                    DualPermissionAdminController::class,
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideCanView')]
+    public function testCanView(?string $fixtureName, array $allowed): void
+    {
+        $allControllers = [
+            CMSProfileController::class,
+            SecurityAdmin::class,
+            TestAdminController::class,
+            DualPermissionAdminController::class,
+        ];
+        $this->logOut();
+        $user = null;
+        if ($fixtureName !== null) {
+            $user = $this->objFromFixture(Member::class, $fixtureName);
+            $this->logInAs($user);
+        }
+
+        foreach ($allowed as $allowedClass) {
+            $this->assertTrue($allowedClass::singleton()->canView(), 'Tried to access ' . $allowedClass);
+        }
+        $disallowed = array_diff($allControllers, $allowed);
+        foreach ($disallowed as $disallowedClass) {
+            $this->assertFalse($disallowedClass::singleton()->canView(), 'Tried to access ' . $disallowedClass);
+        }
+    }
+
+    public static function provideJsonSuccess(): array
+    {
+        return [
+            [
+                'statusCode' => 201,
+                'data' => null,
+                'expectedBody' => '',
+                'expectedException' => '',
+            ],
+            [
+                'statusCode' => 200,
+                'data' => [],
+                'expectedBody' => '[]',
+                'expectedException' => '',
+            ],
+            [
+                'statusCode' => 200,
+                'data' => [1, "two", 3.3],
+                'expectedBody' => '[1,"two",3.3]',
+                'expectedException' => '',
+            ],
+            [
+                'statusCode' => 200,
+                'data' => ['foo' => 'bar', 'quotes' => '"something"', 'array' => [1, 2, 3]],
+                'expectedBody' => '{"foo":"bar","quotes":"\"something\"","array":[1,2,3]}',
+                'expectedException' => '',
+            ],
+            [
+                'statusCode' => 200,
+                'data' => ['unicode' => ['one' => 'ōōō', 'two' => '℅℅℅', 'three' => '👍👍👍']],
+                'expectedBody' => '{"unicode":{"one":"ōōō","two":"℅℅℅","three":"👍👍👍"}}',
+                'expectedException' => '',
+            ],
+            [
+                'statusCode' => 199,
+                'data' => [],
+                'expectedBody' => '',
+                'expectedException' => InvalidArgumentException::class,
+            ],
+            [
+                'statusCode' => 302,
+                'data' => [],
+                'expectedBody' => '',
+                'expectedException' => InvalidArgumentException::class,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideJsonSuccess')]
+    public function testJsonSuccess(
+        int $statusCode,
+        ?array $data,
+        string $expectedBody,
+        string $expectedException
+    ): void {
+        $controller = new TestAdminController();
+        $refelectionObject = new ReflectionObject($controller);
+        $method = $refelectionObject->getMethod('jsonSuccess');
+        $method->setAccessible(true);
+        if ($expectedException) {
+            $this->expectException($expectedException);
+        }
+        $response = $method->invoke($controller, $statusCode, $data);
+        $this->assertSame('application/json', $response->getHeader('Content-type'));
+        $this->assertSame($statusCode, $response->getStatusCode());
+        $this->assertSame($expectedBody, $response->getBody());
+    }
+
+    public static function provideJsonError(): array
+    {
+        return [
+            [
+                'statusCode' => 400,
+                'errorMessage' => '',
+                'expectedValue' => 'Sorry, it seems there was something wrong with the request.',
+            ],
+            [
+                'statusCode' => 401,
+                'errorMessage' => '',
+                'expectedValue' => 'Sorry, it seems you are not authorised to access this section or object.',
+            ],
+            [
+                'statusCode' => 403,
+                'errorMessage' => '',
+                'expectedValue' => 'Sorry, it seems the action you were trying to perform is forbidden.',
+            ],
+            [
+                'statusCode' => 404,
+                'errorMessage' => '',
+                'expectedValue' => 'Sorry, it seems you were trying to access a section or object that doesn\'t exist.',
+            ],
+            [
+                'statusCode' => 500,
+                'errorMessage' => '',
+                'expectedValue' => 'Sorry, it seems there was an internal server error.',
+            ],
+            [
+                'statusCode' => 503,
+                'errorMessage' => '',
+                'expectedValue' => 'Sorry, it seems the service is temporarily unavailable.',
+            ],
+            [
+                'statusCode' => 418,
+                'errorMessage' => '',
+                'expectedValue' => 'Error',
+            ],
+            [
+                'statusCode' => 400,
+                'errorMessage' => 'Test custom error message',
+                'expectedValue' => 'Test custom error message',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideJsonError')]
+    public function testJsonError(
+        int $statusCode,
+        string $errorMessage,
+        ?string $expectedValue,
+    ): void {
+        $controller = new TestAdminController();
+        $refelectionObject = new ReflectionObject($controller);
+        $method = $refelectionObject->getMethod('jsonError');
+        $method->setAccessible(true);
+        $this->expectException(HTTPResponse_Exception::class);
+        $expectedMessage = json_encode((object) [
+            'status' => 'error',
+            'errors' => [
+                (object) [
+                    'type' => 'error',
+                    'code' => $statusCode,
+                    'value' => $expectedValue,
+                ],
+            ],
+        ]);
+        $this->expectExceptionMessage($expectedMessage);
+        $method->invoke($controller, $statusCode, $errorMessage);
+    }
+}

--- a/tests/php/AdminControllerTest.yml
+++ b/tests/php/AdminControllerTest.yml
@@ -9,6 +9,10 @@ SilverStripe\Security\Group:
     Title: allcmssections
   rooteditusers:
     Title: rooteditusers
+  permission1:
+    Title: permission1
+  permission2:
+    Title: permission2
 SilverStripe\Security\Member:
   admin:
     Email: admin@example.com
@@ -23,6 +27,17 @@ SilverStripe\Security\Member:
   rootedituser:
     Email: rootedituser@test.com
     Groups: =>SilverStripe\Security\Group.rooteditusers
+  noaccessuser:
+    Email: noaccessuser@test.com
+  permission1user:
+    Email: permission1user@test.com
+    Groups: =>SilverStripe\Security\Group.permission1
+  permission2user:
+    Email: permission2user@test.com
+    Groups: =>SilverStripe\Security\Group.permission2
+  permission1and2user:
+    Email: permission1and2user@test.com
+    Groups: =>SilverStripe\Security\Group.permission1,=>SilverStripe\Security\Group.permission2
 SilverStripe\Security\Permission:
   admin:
     Code: ADMIN
@@ -36,3 +51,9 @@ SilverStripe\Security\Permission:
   allcmssections2:
     Code: CMS_ACCESS_LeftAndMain
     GroupID: =>SilverStripe\Security\Group.rooteditusers
+  permission1:
+    Code: PERMISSION1
+    GroupID: =>SilverStripe\Security\Group.permission1
+  permission2:
+    Code: PERMISSION2
+    GroupID: =>SilverStripe\Security\Group.permission2

--- a/tests/php/AdminControllerTest/DualPermissionAdminController.php
+++ b/tests/php/AdminControllerTest/DualPermissionAdminController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\Admin\Tests\LeftAndMainTest;
+
+use SilverStripe\Admin\AdminController;
+use SilverStripe\Dev\TestOnly;
+
+class DualPermissionAdminController extends AdminController implements TestOnly
+{
+    private static string|array $required_permission_codes = [
+        'PERMISSION1',
+        'PERMISSION2',
+    ];
+}

--- a/tests/php/AdminControllerTest/TestAdminController.php
+++ b/tests/php/AdminControllerTest/TestAdminController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SilverStripe\Admin\Tests\LeftAndMainTest;
+
+use SilverStripe\Admin\AdminController;
+use SilverStripe\Dev\TestOnly;
+
+class TestAdminController extends AdminController implements TestOnly
+{
+    // no-op - we just want a non-abstract controller.
+}

--- a/tests/php/SecurityAdminTest.php
+++ b/tests/php/SecurityAdminTest.php
@@ -10,7 +10,7 @@ use SilverStripe\Security\Permission;
 
 class SecurityAdminTest extends FunctionalTest
 {
-    protected static $fixture_file = 'LeftAndMainTest.yml';
+    protected static $fixture_file = 'AdminControllerTest.yml';
 
     // public function testGroupExport() {
     //  $this->session()->inst_set('loggedInAs', $this->idFromFixture('Member', 'admin'));

--- a/tests/php/SudoModeControllerTest.php
+++ b/tests/php/SudoModeControllerTest.php
@@ -88,7 +88,7 @@ class SudoModeControllerTest extends FunctionalTest
             'Password' => 'wrongpassword!',
         ]);
 
-        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(401, $response->getStatusCode());
         $result = json_decode((string) $response->getBody(), true);
         $this->assertFalse($result['result'], 'Should have failed with incorrect password');
         $this->assertEquals('Incorrect password', $result['message']);


### PR DESCRIPTION
There are two commits here:

1. Mostly-unrelated refactor to use config instead of runtime code to remove the `CMSProfileController` menu item
2. Add the new `AdminController` class and wire it up

I've also added a bunch of strong typing to the new class and to `AdminRouteController`.
I have _not_ added strong typing to `LeftAndMain` though that may happen as part of a follow-up card in this epic.
I have _not_ added strong typing to methods which would required extensive trickle-down effects (e.g. `init()` and `canView()`).

## Issue
- https://github.com/silverstripe/silverstripe-admin/issues/1761