### PR TITLE
Adding `ignore_menuitem` into LeftAndMain

### DIFF
--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -116,6 +116,12 @@ class LeftAndMain extends Controller implements PermissionProvider
     private static $url_priority = 50;
 
     /**
+     * @config
+     * @var string
+     */
+    private static bool $ignore_menuitem = false;
+
+    /**
      * A subclass of {@link DataObject}.
      *
      * Determines what is managed in this interface, through

--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -116,7 +116,7 @@ class LeftAndMain extends Controller implements PermissionProvider
     private static $url_priority = 50;
 
     /**
-     * Set this to true not display the menu item 
+     * When set to true, this controller isn't given a menu item in the left panel in the CMS. 
      */
     private static bool $ignore_menuitem = false;
 

--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -116,8 +116,7 @@ class LeftAndMain extends Controller implements PermissionProvider
     private static $url_priority = 50;
 
     /**
-     * @config
-     * @var string
+     * Set this to false not display the menu item 
      */
     private static bool $ignore_menuitem = false;
 

--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -116,7 +116,7 @@ class LeftAndMain extends Controller implements PermissionProvider
     private static $url_priority = 50;
 
     /**
-     * When set to true, this controller isn't given a menu item in the left panel in the CMS. 
+     * When set to true, this controller isn't given a menu item in the left panel in the CMS.
      */
     private static bool $ignore_menuitem = false;
 

--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -116,7 +116,7 @@ class LeftAndMain extends Controller implements PermissionProvider
     private static $url_priority = 50;
 
     /**
-     * Set this to false not display the menu item 
+     * Set this to true not display the menu item 
      */
     private static bool $ignore_menuitem = false;
 


### PR DESCRIPTION
## Description
Adds the configuration `ignore_menuitem` into LeftAndMain so that anyone looking at the class will knows that this configuration exists. This will also now show up in the API docs (I think).

## Issues
- #1845 

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
