### PR TITLE
DOC Remove note about deprecation from comment.

### DIFF
--- a/client/src/styles/legacy/_style.scss
+++ b/client/src/styles/legacy/_style.scss
@@ -74,9 +74,6 @@ html, body {
 // .cms-menu,
 // .cms-content,
 // .cms-content-header,
-// // DEPRECATED:
-// // .cms-content-tools will be removed in 4.0
-// // Use .cms-content-filters instead
 // .cms-content-tools,
 // .cms-content-fields,
 // .cms-preview,

--- a/client/src/styles/legacy/_tree.scss
+++ b/client/src/styles/legacy/_tree.scss
@@ -630,10 +630,6 @@
 }
 
 /**
- * DEPRECATED:
- * .cms-content-tools will be removed in 4.0
- * Use .cms-content-filters instead.
- *
  * Ensure status is visible in sidebar
  */
 .cms-content-tools .cms-tree.jstree {


### PR DESCRIPTION
Looks like there was a css class that was MEANT to have been removed, but wasn't and there's no reason to right now. Eventually we'll have to burn the existing styling to the ground, but for now this works and there's no reason to change it.

## Issue
- https://github.com/silverstripe/.github/issues/311