### PR TITLE
FIX Ensure record exists before trying to update TreeTitle

### DIFF
--- a/code/CMSBatchAction.php
+++ b/code/CMSBatchAction.php
@@ -108,12 +108,12 @@ abstract class CMSBatchAction
 
             // Now make sure the tree title is appropriately updated
             $publishedRecord = DataObject::get_by_id($this->managedClass, $id);
-            if ($publishedRecord instanceof SiteTree) {
-                $treeTitle = CMSMain::singleton()->getRecordTreeMarkup($publishedRecord);
-            } else {
-                $treeTitle = $publishedRecord->TreeTitle;
-            }
             if ($publishedRecord) {
+                if ($publishedRecord instanceof SiteTree) {
+                    $treeTitle = CMSMain::singleton()->getRecordTreeMarkup($publishedRecord);
+                } else {
+                    $treeTitle = $publishedRecord->TreeTitle;
+                }
                 $status['modified'][$id] = [
                     'TreeTitle' => $treeTitle,
                 ];


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-admin/issues/1895

Regression introduced [here](https://github.com/silverstripe/silverstripe-admin/commit/b42c820c44a90b10136d9ce78629c1119eb74c65#diff-d9091c39d47fdfe4f05392bdd1ada56cc04b05009a1c7005c8a0215abb33f023R114)

Issue is that while the page exists at the start of [SilverStripe\Admin\CMSBatchAction::batchaction()](https://github.com/silverstripe/silverstripe-admin/blob/2/code/CMSBatchAction.php#L95), the call to `call_user_func_array([$obj, $helperMethod], $arguments ?? [])` will call `doArchive()` meaning that the future assignment to `$publishedRecord` will be `null`, meaning that `$publishedRecord->TreeTitle;` will fail

