### PR TITLE
FIX Fix localisation entities for text collection

### DIFF
--- a/tests/php/AdminControllerTest.php
+++ b/tests/php/AdminControllerTest.php
@@ -199,7 +199,7 @@ class AdminControllerTest extends FunctionalTest
             [
                 'statusCode' => 418,
                 'errorMessage' => '',
-                'expectedValue' => 'Error',
+                'expectedValue' => 'Sorry, it seems there was a 418 error.',
             ],
             [
                 'statusCode' => 400,


### PR DESCRIPTION
Resolves a problem with collected localisation strings identified when running tx-translator:

- https://github.com/silverstripe/silverstripe-admin/pull/1932#discussion_r2085924448


## Issue
- https://github.com/silverstripe/.github/issues/400
