### PR TITLE
ENH SecurityAdmin Tabs translatable with yml

### DIFF
--- a/code/SecurityAdmin.php
+++ b/code/SecurityAdmin.php
@@ -68,16 +68,21 @@ class SecurityAdmin extends ModelAdmin implements PermissionProvider
     {
         $models = parent::getManagedModels();
         // Ensure tab titles can be localised
-        foreach ($models as $key => $spec) {
+        foreach ($models as $key => &$spec) {
             switch ($spec['dataClass']) {
                 case Member::class:
-                    $spec['title'] = _t(__CLASS__ . '.Users', 'Users');
+                    $spec['title'] = _t(__CLASS__ . '.TABUSERS', 'Users');
                     break;
                 case Group::class:
+                    $spec['title'] = _t(__CLASS__ . '.TABGROUPS', 'Groups');
+                    break;
                 case PermissionRole::class:
-                    $spec['title'] = singleton($spec['dataClass'])->i18n_plural_name();
+                    $spec['title'] = _t(__CLASS__ . '.TABROLES', 'Roles');
             }
         }
+
+        unset($spec);
+
         return $models;
     }
 

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -106,8 +106,9 @@ de:
     IMPORTUSERS: 'Benutzer importieren'
     MENUTITLE: Sicherheit
     MemberListCaution: 'Achtung: Benutzer von dieser Liste zu entfernen, wird diese von allen Gruppen entfernen und aus der Datenbank löschen.'
-    TABROLES: Rollen
-    Users: Benutzer
+    TABUSERS: 'Benutzer'
+    TABGROUPS: 'Gruppen'
+    TABROLES: 'Rollen'
   SilverStripe\Admin\SudoModeController:
     INVALID: 'Falsches Passwort'
     TIMEOUT: 'Sitzung wurde unterbrochen, bitte aktualisieren Sie und versuchen Sie es erneut.'

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -128,8 +128,9 @@ en:
     ImportFormHelpMember: '<p>Groups can be assigned by the <em>Groups</em> column. Groups are identified by their <em>Code</em> property, multiple groups can be separated by comma. Existing group memberships are not cleared.</p>'
     MENUTITLE: Security
     MemberListCaution: 'Caution: Removing members from this list will remove them from all groups and the database'
-    TABROLES: Roles
-    Users: Users
+    TABUSERS: 'Users'
+    TABGROUPS: 'Groups'
+    TABROLES: 'Roles'
   SilverStripe\Admin\SudoModeController:
     INVALID: 'Incorrect password'
     ImportFormHelpGroup: '<ul><li>Existing groups are matched by their unique <em>Code</em> value, and updated with any new values from the imported file</li><li>Group hierarchies can be created by using a <em>ParentCode</em> column.</li><li>Permission codes can be assigned by the <em>PermissionCode</em> column. Existing permission codes are not cleared.</li></ul>'


### PR DESCRIPTION
the few translations that were in example de.yml did not get used in SecurityAdmin
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
We wanted the SecurityAdmin Tabs (Users, Groups, Roles) to be translated (again?)
The Tabs inside SecurityAdmin are now translated.
before
![Bildschirmfoto 2025-06-23 um 15 52 23](https://github.com/user-attachments/assets/eddc9ef8-ac53-490b-b26a-5cd4e36e3f85)

after
![Bildschirmfoto 2025-06-23 um 16 39 16](https://github.com/user-attachments/assets/42c20100-de4a-464d-bfeb-77437261bf80)

<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->

## Manual testing steps

1. Install SilverStripe 6 and change the Language to DE
2. Go to ModelAdmin Security("Sicherheit")
3. Check if the Tabs are translated. 
4. Change translation in vendor/silverstripe/admin/lang/de.yml
5. flush so translations get renewed
6. Check if translation worked
7. Optional: add a translation in a other language

<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

## Issues
https://github.com/silverstripe/silverstripe-admin/issues/1946 -> SecurityAdmin Tabs could not be trasnlated per YML.
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [ ] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [ ] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
