### PR TITLE
FIX Allow security admin tabs to be localised

### DIFF
--- a/code/SecurityAdmin.php
+++ b/code/SecurityAdmin.php
@@ -74,11 +74,11 @@ class SecurityAdmin extends ModelAdmin implements PermissionProvider
         foreach ($models as $key => $spec) {
             switch ($spec['dataClass']) {
                 case Member::class:
-                    $spec['title'] = _t(__CLASS__ . '.Users', 'Users');
+                    $models[$key]['title'] = _t(__CLASS__ . '.Users', 'Users');
                     break;
                 case Group::class:
                 case PermissionRole::class:
-                    $spec['title'] = singleton($spec['dataClass'])->i18n_plural_name();
+                    $models[$key]['title'] = singleton($spec['dataClass'])->i18n_plural_name();
             }
         }
         return $models;


### PR DESCRIPTION
Test with this content in `app/lang/en.yml` and flush:

```yaml
en:
  SilverStripe\Admin\SecurityAdmin:
    Users: 'Userz'
  SilverStripe\Security\Group:
    PLURALNAME: 'Groupz'
  SilverStripe\Security\PermissionRole:
    PLURALNAME: 'Rolez'
```

## Issue

- https://github.com/silverstripe/silverstripe-admin/issues/1946