### PR TITLE
ENH Use new DataList caching

### DIFF
--- a/code/CMSBatchAction.php
+++ b/code/CMSBatchAction.php
@@ -107,7 +107,7 @@ abstract class CMSBatchAction
             }
 
             // Now make sure the tree title is appropriately updated
-            $publishedRecord = DataObject::get_by_id($this->managedClass, $id);
+            $publishedRecord = DataObject::get($this->managedClass)->setUseCache(true)->byID($id);
             if ($publishedRecord) {
                 if ($publishedRecord instanceof SiteTree) {
                     $treeTitle = CMSMain::singleton()->getRecordTreeMarkup($publishedRecord);

--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -790,7 +790,7 @@ class LeftAndMain extends FormSchemaController implements PermissionProvider
             return DataObject::singleton($className);
         }
         if (is_numeric($id)) {
-            return DataObject::get_by_id($className, $id);
+            return DataObject::get($className)->setUseCache(true)->byID($id);
         }
         return null;
     }
@@ -822,7 +822,7 @@ class LeftAndMain extends FormSchemaController implements PermissionProvider
         // Existing or new record?
         $id = $data['ID'];
         if (is_numeric($id) && $id > 0) {
-            $record = DataObject::get_by_id($className, $id);
+            $record = DataObject::get($className)->setUseCache(true)->byID($id);
             if ($record && !$record->canEdit()) {
                 return Security::permissionFailure($this);
             }
@@ -879,7 +879,7 @@ class LeftAndMain extends FormSchemaController implements PermissionProvider
         $className = $this->getModelClass();
 
         $id = $data['ID'];
-        $record = DataObject::get_by_id($className, $id);
+        $record = DataObject::get($className)->setUseCache(true)->byID($id);
         if ($record && !$record->canDelete()) {
             return Security::permissionFailure();
         }

--- a/code/SingleRecordAdmin.php
+++ b/code/SingleRecordAdmin.php
@@ -46,7 +46,7 @@ abstract class SingleRecordAdmin extends LeftAndMain
         $record = null;
         $modelClass = $this->getModelClass();
         if (static::config()->get('restrict_to_single_record')) {
-            $record = DataObject::get_one($modelClass);
+            $record = DataObject::get($modelClass)->setUseCache(true)->first();
         }
         if (!$record && static::config()->get('allow_new_record')) {
             $record = $modelClass::create();

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "silverstripe/versioned": "^3"
     },
     "require-dev": {


### PR DESCRIPTION
Replaces deprecated `DataObject::get_one()` and `DataObject::get_by_id()` in favour of the new DataList query caching.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11768
> DO NOT MERGE until that PR has been merged in

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767
