### PR TITLE
ENH Use nav element for cms-menu

### DIFF
--- a/templates/SilverStripe/Admin/Includes/LeftAndMain_Menu.ss
+++ b/templates/SilverStripe/Admin/Includes/LeftAndMain_Menu.ss
@@ -1,6 +1,6 @@
 <div class="cms-mobile-menu-toggle-wrapper"></div>
 
-<div class="fill-height cms-menu cms-panel cms-panel-layout" id="cms-menu" data-layout-type="border" aria-expanded="false">
+<nav class="fill-height cms-menu cms-panel cms-panel-layout" id="cms-menu" data-layout-type="border" aria-label="<%t SilverStripe\\Admin\\LeftAndMain_Menu.MainMenu 'Main menu' %>" aria-expanded="false">
 	<div class="cms-menu__header">
 		<% include SilverStripe\\Admin\\LeftAndMain_MenuLogo %>
 		<% include SilverStripe\\Admin\\LeftAndMain_MenuStatus %>
@@ -13,6 +13,6 @@
 	<div class="toolbar toolbar--south cms-panel-toggle">
 		<% include SilverStripe\\Admin\\LeftAndMain_MenuToggle %>
 	</div>
-</div>
+</nav>
 
 <button class="fill-height fill-width cms-menu-mobile-overlay" aria-controls="cms-menu" aria-expanded="false"></button>


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-admin/issues/1971

I couldn't find any CSS or JSS that prefixed the selector with `div` i.e. `div.cms-menu` or `div#cms-menu`, so I think it's safe to just change the tag