### PR TITLE
ENH Use initial-scale instead of maximum-scale

### DIFF
--- a/templates/SilverStripe/Admin/LeftAndMain.ss
+++ b/templates/SilverStripe/Admin/LeftAndMain.ss
@@ -3,7 +3,7 @@
 	<head>
 	<% base_tag %>
 	<meta http-equiv="Content-type" content="text/html; charset=utf-8" />
-	<meta name="viewport" content="width=device-width, maximum-scale=1.0" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>$Title</title>
 </head>
 <body class="loading cms" data-frameworkpath="$ModulePath(silverstripe/framework)"


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-admin/issues/1958

This can be tested on desktop by using developer tools in chrome, selecting "Toggle device toolbar", holding down shift and left click while moving the mouse up or down