### PR TITLE
MNT Fix unit test for script attribute order

### DIFF
--- a/tests/php/LeftAndMainTest.php
+++ b/tests/php/LeftAndMainTest.php
@@ -96,7 +96,8 @@ class LeftAndMainTest extends FunctionalTest
             'body should contain custom js'
         );
         $this->assertMatchesRegularExpression(
-            '/<script.*?src="[^"]*?tests\/php\/assets\/LeftAndMainTestWithOptions\.js.*?crossorigin="anonymous".*?>/i',
+            // positive look ahead used because the `crossorigin` might be before or after the `src` - but either is fine.
+            '/<script(?=[^<>]*?crossorigin="anonymous").*?(src="[^"]*?tests\/php\/assets\/LeftAndMainTestWithOptions\.js).*?>/i',
             $response->getBody(),
             'body should contain custom js with options'
         );


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-admin/actions/runs/18549159933/job/52873197252

> SilverStripe\Admin\Tests\LeftAndMainTest::testExtraCssAndJavascript
> body should contain custom js with options

Note that the prefer-lowest build shouldn't have been failing, since this module has a lowest framework dep of `^6.1` which doesn't have the code that broke the test.... but since it's using installer `6.x-dev` it installs framework `6.x-dev` as well. Something we might want to deal with eventually.
For now that's just context as to why I made the order not matter, rather than just using the new 6.2 order directly.

## Issue

- https://github.com/silverstripe/.github/issues/459