### PR TITLE
FIX Ensure arg is integer like

### DIFF
--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -1032,7 +1032,7 @@ class LeftAndMain extends Controller implements PermissionProvider
     public function show(HTTPRequest $request): HTTPResponse
     {
         if ($request->param('ID')) {
-            $this->setCurrentRecordID($request->param('ID'));
+            $this->setCurrentRecordID((int) $request->param('ID'));
         }
         return $this->getResponseNegotiator()->respond($request);
     }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-admin/issues/2030

Original issue can be replicated by going to `/admin/pages/edit/show/def`

If a non integer value is passed, then it will simply use the last loaded value instead e.g. if I was previously on the "About us" page `/admin/pages/edit/show/2`, then going to `/admin/pages/edit/show/def` will show the "About us" page
