### PR TITLE
FIX: Add default templates for SingleRecordAdmin (fixes #2057)

### DIFF
--- a/code/SingleRecordAdmin.php
+++ b/code/SingleRecordAdmin.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Admin;
 
 use SilverStripe\Forms\Form;
+use SilverStripe\Forms\HiddenField;
 use SilverStripe\ORM\DataObject;
 
 /**
@@ -25,6 +26,19 @@ abstract class SingleRecordAdmin extends LeftAndMain
 
     public function getEditForm($id = null, $fields = null): ?Form
     {
+        if (!$fields) {
+            if (!$id) {
+                $id = $this->currentRecordID();
+            }
+            $record = $this->getRecord($id);
+            if ($record) {
+                $fields = $record->getCMSFields();
+            }
+        }
+        if ($fields && !$fields->dataFieldByName('ID')) {
+            $fields->add(HiddenField::create('ID'));
+        }
+
         $form = parent::getEditForm($id, $fields);
         // Keep the tabs on the top row, rather than underneath
         if ($form?->Fields()->hasTabSet()) {

--- a/code/SingleRecordAdmin.php
+++ b/code/SingleRecordAdmin.php
@@ -28,6 +28,7 @@ abstract class SingleRecordAdmin extends LeftAndMain
         $form = parent::getEditForm($id, $fields);
         // Keep the tabs on the top row, rather than underneath
         if ($form?->Fields()->hasTabSet()) {
+            $form->addExtraClass('cms-tabset'); // Required for tabsets to work, see CMSTabSet.ss for info
             $form->Fields()->findOrMakeTab('Root')->setTemplate('SilverStripe/Forms/CMSTabSet');
         }
         return $form;


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
Targeted this at the `3` branch because if we later opt to remove the matching templates from the siteconfig repo, we can then update the `composer.json` requirement to point to a minor release e.g. `"silverstripe/admin": "^3.2"`.  I suppose that constraint _could_ point to a patch release, but that feels weird to me for some reason... happy to be overruled on that.

## Manual testing steps
See reproduction steps in https://github.com/silverstripe/silverstripe-admin/issues/2057#issue-3617178304. Without these templates, the edit form won’t be visible.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #2057

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [ ] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
