### PR TITLE
MNT Update unit tests for PHP 8.5

### DIFF
--- a/tests/php/AdminControllerTest.php
+++ b/tests/php/AdminControllerTest.php
@@ -153,7 +153,6 @@ class AdminControllerTest extends FunctionalTest
         $controller = new TestAdminController();
         $refelectionObject = new ReflectionObject($controller);
         $method = $refelectionObject->getMethod('jsonSuccess');
-        $method->setAccessible(true);
         if ($expectedException) {
             $this->expectException($expectedException);
         }
@@ -218,7 +217,6 @@ class AdminControllerTest extends FunctionalTest
         $controller = new TestAdminController();
         $refelectionObject = new ReflectionObject($controller);
         $method = $refelectionObject->getMethod('jsonError');
-        $method->setAccessible(true);
         $this->expectException(HTTPResponse_Exception::class);
         $expectedMessage = json_encode((object) [
             'status' => 'error',

--- a/tests/php/ModelAdminTest.php
+++ b/tests/php/ModelAdminTest.php
@@ -362,7 +362,6 @@ class ModelAdminTest extends FunctionalTest
     {
         $admin = new ModelAdminTest\MultiModelAdmin();
         $reflectionMethod = new ReflectionMethod($admin, 'getModelTabForModelClass');
-        $reflectionMethod->setAccessible(true);
         $this->assertSame(Contact::class, $reflectionMethod->invoke($admin, Contact::class));
         $this->assertSame(Contact::class, $reflectionMethod->invoke($admin, ContactSubclass::class));
         $this->assertSame('Player', $reflectionMethod->invoke($admin, Player::class));
@@ -372,7 +371,6 @@ class ModelAdminTest extends FunctionalTest
     {
         $admin = new ModelAdminTest\MultiModelAdmin();
         $reflectionMethod = new ReflectionMethod($admin, 'getModelTabForModelClass');
-        $reflectionMethod->setAccessible(true);
         $this->expectException(InvalidArgumentException::class);
         $reflectionMethod->invoke($admin, 'cricket-players');
     }
@@ -393,7 +391,6 @@ class ModelAdminTest extends FunctionalTest
             ]);
 
         $reflectionMethod = new ReflectionMethod($mock, 'getModelTabForModelClass');
-        $reflectionMethod->setAccessible(true);
         $this->assertSame(Player::class, $reflectionMethod->invoke($mock, Player::class));
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- The setAccessible() methods of various Reflection objects have been deprecated, as those no longer have an effect.
