### PR TITLE
TLN Add translatable text for pagination

### DIFF
--- a/client/lang/src/en.json
+++ b/client/lang/src/en.json
@@ -54,6 +54,7 @@
     "Admin.OWNED_WARNING_1": "You are unpublishing content that is being used in {count} other published section(s).",
     "Admin.OWNED_WARNING_2": "This could cause a published page to have missing components on the live site.",
     "Admin.OWNED_WARNING_3": "Do you want to unpublish anyway?",
+    "Admin.PAGE_OF_PAGES": "Page {current} of {total}",
     "Admin.PAGINATION": "Pagination",
     "Admin.PAGINATION_FOR_TITLE": "Pagination for {title}",
     "Admin.PREVIEW_MODE": "Preview mode",


### PR DESCRIPTION
This generic piece of text is likely to be used for all paginated roving tabindex areas in the CMS (e.g. asset admin gallery, gridfield. etc) as we update them.

It's used by the asset admin gallery in https://github.com/silverstripe/silverstripe-asset-admin/pull/1643

## Issue

- https://github.com/silverstripe/silverstripe-asset-admin/issues/1618