### PR TITLE
FIX Suppress deprecation notice for SSViewer.enable_base_tag

### DIFF
--- a/code/AdminRootController.php
+++ b/code/AdminRootController.php
@@ -8,6 +8,7 @@ use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\View\SSViewer;
 use SilverStripe\View\TemplateGlobalProvider;
 
@@ -60,7 +61,7 @@ class AdminRootController extends Controller implements TemplateGlobalProvider
         $parts = [AdminRootController::get_admin_route(), $action];
         // If the base tag is disabled, we need to make the admin URL absolute to ensure it works correctly
         // As a major version chagne, we could drop this condition and always prefix with Director::baseURL()
-        if (!SSViewer::config()->get('enable_base_tag')) {
+        if (!Deprecation::withSuppressedNotice(fn() => SSViewer::config()->get('enable_base_tag'))) {
             array_unshift($parts, Director::baseURL());
         }
         return Controller::join_links(...$parts);


### PR DESCRIPTION
When we try to get values for deprecated config, a deprecation notice gets emitted. If we can't avoid getting the config value for now, we need to suppress the notice.


## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11969