### PR TITLE
FIX Normalise reactRoutePath to always provide leading slash

### DIFF
--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -358,6 +358,8 @@ class LeftAndMain extends Controller implements PermissionProvider
         // Allows the section name to be overridden in config
         $name = $this->config()->get('section_name');
         $url = trim($this->Link() ?? '', '/');
+        $reactRoutePath = preg_replace('/^' . preg_quote(AdminRootController::admin_url(), '/') . '/', '', $url);
+        $reactRoutePath = '/' . ltrim($reactRoutePath ?? '', '/');
 
         if (!$name) {
             $name = static::class;
@@ -368,7 +370,7 @@ class LeftAndMain extends Controller implements PermissionProvider
             // and use in routing definitions.
             'name' => $name,
             'url' => $url,
-            'reactRoutePath' => preg_replace('/^' . preg_quote(AdminRootController::admin_url(), '/') . '/', '', $url),
+            'reactRoutePath' => $reactRoutePath,
             'form' => [
                 'EditorExternalLink' => [
                     'schemaUrl' => $this->Link('methodSchema/Modals/EditorExternalLink'),

--- a/tests/php/LeftAndMainTest.php
+++ b/tests/php/LeftAndMainTest.php
@@ -132,6 +132,14 @@ class LeftAndMainTest extends FunctionalTest
         $this->assertMatchesRegularExpression('/<body[^>]*>/i', $response->getBody(), "$link should contain <body> tag");
     }
 
+    public function testGetClientConfigNormalisesReactRoutePath()
+    {
+        $controller = MyTreeController::singleton();
+        $config = $controller->getClientConfig();
+
+        $this->assertSame('/mytree/edit', $config['reactRoutePath']);
+    }
+
     public function testCanView()
     {
         $adminuser = $this->objFromFixture(Member::class, 'admin');


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-asset-admin/issues/1655

Alternative to https://github.com/silverstripe/silverstripe-asset-admin/pull/1675

Note: does not appear to work
