### PR TITLE
DOC Correct typos with codespell in code, comments, and tests

### DIFF
--- a/code/AdminRootController.php
+++ b/code/AdminRootController.php
@@ -21,7 +21,7 @@ use SilverStripe\View\TemplateGlobalProvider;
 class AdminRootController extends Controller implements TemplateGlobalProvider
 {
     /**
-     * Fallback admin URL in case this cannot be infered from Director.rules
+     * Fallback admin URL in case this cannot be inferred from Director.rules
      */
     private static string $url_base = 'admin';
 
@@ -60,7 +60,7 @@ class AdminRootController extends Controller implements TemplateGlobalProvider
     {
         $parts = [AdminRootController::get_admin_route(), $action];
         // If the base tag is disabled, we need to make the admin URL absolute to ensure it works correctly
-        // As a major version chagne, we could drop this condition and always prefix with Director::baseURL()
+        // As a major version change, we could drop this condition and always prefix with Director::baseURL()
         if (!Deprecation::withSuppressedNotice(fn() => SSViewer::config()->get('enable_base_tag'))) {
             array_unshift($parts, Director::baseURL());
         }

--- a/code/CMSMenu.php
+++ b/code/CMSMenu.php
@@ -135,7 +135,7 @@ class CMSMenu implements IteratorAggregate, i18nEntityProvider
      *                    {@link remove_menu_item}. Also used as a CSS-class for icon customization.
      * @param string $menuTitle Localized title showing in the menu bar
      * @param string $url A relative URL that will be linked in the menu bar.
-     * @param string $controllerClass The controller class for this menu, used to check permisssions.
+     * @param string $controllerClass The controller class for this menu, used to check permissions.
      *                    If blank, it's assumed that this is public, and always shown to users who
      *                    have the rights to access some other part of the admin area.
      * @param int $priority
@@ -318,7 +318,7 @@ class CMSMenu implements IteratorAggregate, i18nEntityProvider
      * @param string $menuTitle Localized title showing in the menu bar
      * @param string $url A relative URL that will be linked in the menu bar.
      *                    Make sure to add a matching route via {@link Director::$rules} to this url.
-     * @param string $controllerClass The controller class for this menu, used to check permisssions.
+     * @param string $controllerClass The controller class for this menu, used to check permissions.
      *                    If blank, it's assumed that this is public, and always shown to users who
      *                    have the rights to access some other part of the admin area.
      * @param int $priority
@@ -365,7 +365,7 @@ class CMSMenu implements IteratorAggregate, i18nEntityProvider
     }
 
     /**
-     * A utility funciton to retrieve subclasses of a given class that
+     * A utility function to retrieve subclasses of a given class that
      * are instantiable (ie, not abstract) and have a valid menu title.
      *
      * Sorted by url_priority config.

--- a/code/Forms/UnsavedChangesIndicator.php
+++ b/code/Forms/UnsavedChangesIndicator.php
@@ -61,7 +61,7 @@ class UnsavedChangesIndicator extends DatalessField
             throw new RuntimeException('minutes config must contain both "notice" and "warning" keys');
         }
         // Allow decimals here for partial minutes, as this is required for behat
-        // testing and develoment so that we don't have to wait long periods of time
+        // testing and development so that we don't have to wait long periods of time
         if (!is_numeric($minutes['notice']) || !is_numeric($minutes['warning'])) {
             throw new RuntimeException('minutes config values must be numeric');
         }

--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -520,7 +520,7 @@ class LeftAndMain extends FormSchemaController implements PermissionProvider
     public static function menu_title($class = null, $localise = true)
     {
         if ($class && is_subclass_of($class, __CLASS__)) {
-            // Respect oveloading of menu_title() in subclasses
+            // Respect overloading of menu_title() in subclasses
             return $class::menu_title(null, $localise);
         }
         if (!$class) {
@@ -913,7 +913,7 @@ class LeftAndMain extends FormSchemaController implements PermissionProvider
      *
      * @param HTTPRequest $request Passed if executing a HTTPRequest directly on the form.
      * If empty, this is invoked as $EditForm in the template
-     * @return Form Should return a form regardless wether a record has been found.
+     * @return Form Should return a form regardless whether a record has been found.
      *  Form might be readonly if the current user doesn't have the permission to edit
      *  the record.
      */
@@ -1444,7 +1444,7 @@ class LeftAndMain extends FormSchemaController implements PermissionProvider
         ];
 
         // Add any custom ModelAdmin subclasses. Can't put this on ModelAdmin itself
-        // since its marked abstract, and needs to be singleton instanciated.
+        // since its marked abstract, and needs to be singleton instantiated.
         foreach (ClassInfo::subclassesFor(ModelAdmin::class) as $i => $class) {
             if ($class === ModelAdmin::class) {
                 continue;

--- a/code/Navigator/SilverStripeNavigator.php
+++ b/code/Navigator/SilverStripeNavigator.php
@@ -58,7 +58,7 @@ class SilverStripeNavigator extends ModelData
                 continue;
             }
 
-            // This funny litle formula ensures that the first item added with the same priority will be left-most.
+            // This funny little formula ensures that the first item added with the same priority will be left-most.
             $priority = $item->getPriority() * 100 - 1;
 
             // Ensure that we can have duplicates with the same (default) priority

--- a/code/Navigator/SilverStripeNavigatorItem.php
+++ b/code/Navigator/SilverStripeNavigatorItem.php
@@ -12,7 +12,7 @@ use SilverStripe\Model\ModelData;
 /**
  * SilverStripeNavigator items are links that appear in the $SilverStripeNavigator bar.
  * To add an item, extend this class - it will be automatically picked up.
- * When instanciating items manually, please ensure to call {@link canView()}.
+ * When instantiating items manually, please ensure to call {@link canView()}.
  */
 abstract class SilverStripeNavigatorItem extends ModelData
 {

--- a/tests/behat/features/site-settings.feature
+++ b/tests/behat/features/site-settings.feature
@@ -24,7 +24,7 @@ Feature: Site settings
     When I go to "/home"
     Then I should see "Home"
 
-    # Change site visbility
+    # Change site visibility
     When I am logged in with "ADMIN" permissions
     When I go to "/admin/settings"
     When I click the "Access" CMS tab

--- a/tests/php/CMSMenuTest.php
+++ b/tests/php/CMSMenuTest.php
@@ -107,7 +107,7 @@ class CMSMenuTest extends SapphireTest implements TestOnly
     public function testAdvancedMenuHandling()
     {
 
-        // Populate from CMS Classes, check for existance of SecurityAdmin
+        // Populate from CMS Classes, check for existence of SecurityAdmin
         CMSMenu::clear_menu();
         CMSMenu::populate_menu();
         $menuItem = CMSMenu::get_menu_item('SilverStripe-Admin-SecurityAdmin');

--- a/tests/php/CMSProfileControllerTest.php
+++ b/tests/php/CMSProfileControllerTest.php
@@ -32,7 +32,7 @@ class CMSProfileControllerTest extends FunctionalTest
         parent::tearDown();
         $session = Controller::curr()->getRequest()->getSession();
         $service = Injector::inst()->get(SudoModeServiceInterface::class);
-        // deactive() isn't part of the interface
+        // deactivate() isn't part of the interface
         if (method_exists($service, 'deactivate')) {
             call_user_func([$service, 'deactivate'], $session);
         }

--- a/themes/cms-forms/templates/SilverStripe/Forms/CMSTabSet.ss
+++ b/themes/cms-forms/templates/SilverStripe/Forms/CMSTabSet.ss
@@ -1,5 +1,5 @@
 <%-- Exclude ".ss-tabset" class to avoid inheriting behaviour --%>
-<%-- The ".cms-tabset" class needs to be manually applied to a container elment, --%>
+<%-- The ".cms-tabset" class needs to be manually applied to a container element, --%>
 <%-- above the level where the tab navigation is placed. --%>
 <%-- Tab navigation is rendered through various templates, --%>
 <%-- e.g. through LeftAndMain_EditForm.ss. --%>


### PR DESCRIPTION
## Description

Fixed typos throughout the admin module:
- infered → inferred (AdminRootController.php)
- chagne → change (AdminRootController.php)
- permisssions → permissions (CMSMenu.php, 2 occurrences)
- funciton → function (CMSMenu.php)
- oveloading → overloading (LeftAndMain.php)
- wether → whether (LeftAndMain.php)
- instanciated → instantiated (LeftAndMain.php)
- instanciating → instantiating (SilverStripeNavigatorItem.php)
- develoment → development (UnsavedChangesIndicator.php)
- litle → little (SilverStripeNavigator.php)
- elment → element (CMSTabSet.ss template)
- existance → existence (CMSMenuTest.php)
- deactive → deactivate (CMSProfileControllerTest.php)
- visbility → visibility (site-settings.feature)

All changes are to PHPDoc comments, inline comments, error messages, and test files. No functional code changes.

Note: Typos in DependentCompositeField.php and DependentCompositeFieldTest.php regarding "dependant" vs "dependent" are intentionally excluded pending further review.

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green