### PR TITLE
FIX SingleRecordAdmin::currentRecordID() returns URL ?ID= param, breaking TreeDropdownField AJAX.

### DIFF
--- a/code/SingleRecordAdmin.php
+++ b/code/SingleRecordAdmin.php
@@ -24,6 +24,18 @@ abstract class SingleRecordAdmin extends LeftAndMain
      */
     private static bool $allow_new_record = true;
 
+    /**
+     * Single-record admins never use a URL-based record ID — the record is always
+     * fetched via getSingleRecord(). Returning null here prevents query parameters
+     * such as ?ID= (e.g. from a TreeDropdownField AJAX subtree request) from being
+     * mistaken for the managed record's ID, which would cause getEditForm() to return
+     * an empty form and break field AJAX actions.
+     */
+    public function currentRecordID(): ?int
+    {
+        return null;
+    }
+
     public function getEditForm($id = null, $fields = null): ?Form
     {
         if (!$fields) {


### PR DESCRIPTION
## Description
When a TreeDropdownField is placed inside a SingleRecordAdmin (e.g. SiteConfigLeftAndMain) and the tree has enough nodes to trigger AJAX lazy-loading, expanding a node returns a 404:

I can't handle sub-URLs on class SilverStripe\Forms\FormRequestHandler.
The field works when the tree is small enough to be pre-populated without AJAX. The bug does not affect page editing in CMSMain. This is a regression from 6.1.x.

## Manual testing steps
See: https://github.com/silverstripe/silverstripe-framework/issues/11984

## Issues
See: https://github.com/silverstripe/silverstripe-framework/issues/11984