### PR TITLE
FIX Stop single record admins reading ID from request

### DIFF
--- a/code/SingleRecordAdmin.php
+++ b/code/SingleRecordAdmin.php
@@ -48,6 +48,14 @@ abstract class SingleRecordAdmin extends LeftAndMain
         return $form;
     }
 
+    public function currentRecordID(): ?int
+    {
+        // Unlike parent LeftAndMain, do not fall back to use GET/POST/URL parameters such as 'ID'
+        $id = $this->recordID ? (int) $this->recordID : null;
+        $this->extend('updateCurrentRecordID', $id);
+        return $id;
+    }
+
     public function getRecord($id): ?DataObject
     {
         if (!$id) {

--- a/tests/php/SingleRecordAdminTest.php
+++ b/tests/php/SingleRecordAdminTest.php
@@ -5,6 +5,8 @@ namespace SilverStripe\Admin\Tests;
 use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Admin\Tests\SingleRecordAdminTest\TestAdmin;
 use SilverStripe\Admin\Tests\SingleRecordAdminTest\TestRecord;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\Session;
 use SilverStripe\Dev\SapphireTest;
 
 class SingleRecordAdminTest extends SapphireTest
@@ -113,5 +115,44 @@ class SingleRecordAdminTest extends SapphireTest
         } else {
             $this->assertNull($result);
         }
+    }
+
+    public static function provideCurrentRecordID(): array
+    {
+        return [
+            'unrelated ID request var is ignored' => [
+                'explicitID' => null,
+                'requestVars' => ['ID' => '915', 'format' => 'json'],
+                'expected' => null,
+            ],
+            'explicit id wins over request var' => [
+                'explicitID' => 123,
+                'requestVars' => ['ID' => '915'],
+                'expected' => 123,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideCurrentRecordID')]
+    public function testCurrentRecordID(?int $explicitID, array $requestVars, ?int $expected): void
+    {
+        $admin = new TestAdmin();
+        $admin->setRequest(new HTTPRequest('GET', 'admin/test/EditForm/field/MyField/tree', $requestVars));
+        $admin->setCurrentRecordID($explicitID);
+        $this->assertSame($expected, $admin->currentRecordID());
+    }
+
+    public function testGetEditFormIgnoresUnrelatedIDRequestVar(): void
+    {
+        $this->logInWithPermission('ADMIN');
+        $record = new TestRecord();
+        $recordID = $record->write();
+        $requestVars = ['ID' => $recordID + 1, 'format' => 'json'];
+        $request = new HTTPRequest('GET', 'admin/test/EditForm/field/MyField/tree', $requestVars);
+        $request->setSession(new Session([]));
+        $admin = new TestAdmin();
+        $admin->setRequest($request);
+        $form = $admin->getEditForm();
+        $this->assertSame($recordID, (int) $form->Fields()->dataFieldByName('ID')->dataValue());
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-admin/issues/2168

## Root cause

`LeftAndMain::currentRecordID()` falls back to the `ID` request variable (GET or POST or URL param e.g. `/123`) when no record ID was set explicitly. A `SingleRecordAdmin` never gets its record from the request (or at least it never should) - it should single fetch the single record for that DataObject in the database, or, as is the case with CMSProfileController (/admin/myprofile), programatically set the record via `setCurrentRecordID()` (i.e. do NOT set the ID in the url)

`TreeDropdownField` uses the 'ID' parameter name for something entirely different: the node whose children it wants to lazy-load, e.g. `GET /admin/settings/EditForm/field/PagePickerID/tree?ID=915`. On that request `currentRecordID()` returned `915`, so `SingleRecordAdmin::getRecord(915)` saw a truthy ID, called `parent::getRecord(915)`, found no `SiteConfig` with that ID and returned `null`. `LeftAndMain::getEditForm()` then fell through to `EmptyForm()`, which has no `PagePickerID` field, so `FormRequestHandler::handleField()` returned `null` and responsed with a 404.

## Validation steps

1. Log in as the default admin, create the three files below, then visit `/dev/build?flush=1`

2. Run the task below from `/dev/tasks/MockPagesTask` to create the mock page tree - `Mock Filler` with 40 children exists so that `TreeDropdownField`'s `node_threshold_total` of 30 is reached before `Mock Parent`, leaving `Mock Parent`'s children to be lazy loaded rather than sent with the initial tree request

3. Open `/admin/mock-settings`

4. In the `Pick a page` field, open the dropdown and expand the `Mock Parent` node

5. It was reported that expanding the node returned a 404 reading `I can't handle sub-URLs on class SilverStripe\Forms\FormRequestHandler`; the 60 `Mock Child` pages should now load under `Mock Parent`

6. Open `/admin/myprofile` and confirm the profile form still loads with the logged-in member's details

**app/src/MockSettings.php**

```php
<?php

use SilverStripe\CMS\Model\SiteTree;
use SilverStripe\Forms\FieldList;
use SilverStripe\Forms\TreeDropdownField;
use SilverStripe\ORM\DataObject;

class MockSettings extends DataObject
{
    private static string $table_name = 'MockSettings';

    private static array $db = [
        'Name' => 'Varchar'
    ];

    private static array $has_one = [
        'PagePicker' => SiteTree::class
    ];

    public function getCMSFields()
    {
        return FieldList::create(TreeDropdownField::create('PagePickerID', 'Pick a page', SiteTree::class));
    }
}
```

**app/src/MockSettingsAdmin.php**

```php
<?php

use SilverStripe\Admin\SingleRecordAdmin;

class MockSettingsAdmin extends SingleRecordAdmin
{
    private static $url_segment = 'mock-settings';

    private static $menu_title = 'Mock Settings';

    private static $model_class = MockSettings::class;
}
```

**app/src/MockPagesTask.php**

```php
<?php

use SilverStripe\CMS\Model\SiteTree;
use SilverStripe\Dev\BuildTask;
use SilverStripe\PolyExecution\PolyOutput;
use Symfony\Component\Console\Command\Command;
use Symfony\Component\Console\Input\InputInterface;

class MockPagesTask extends BuildTask
{
    protected string $title = 'Create mock pages for tree lazy loading';

    protected function execute(InputInterface $input, PolyOutput $output): int
    {
        $stale = SiteTree::get()->filterAny([
            'Title' => ['Mock Parent', 'Mock Filler'],
            'Title:StartsWith' => ['Mock Child', 'Mock Padding'],
        ]);
        foreach ($stale->toArray() as $page) {
            $page->doUnpublish();
            $page->delete();
        }
        // Created first so it sorts before Mock Parent. TreeDropdownField.node_threshold_total is 30 and
        // MarkedSet::markPartialTree() walks the tree breadth first, so the 40 children here push the count
        // past the threshold before Mock Parent is reached, leaving Mock Parent's children to be lazy loaded
        $filler = $this->createPage('Mock Filler', 0);
        for ($i = 1; $i <= 40; $i++) {
            $this->createPage("Mock Padding $i", $filler->ID);
        }
        $parent = $this->createPage('Mock Parent', 0);
        for ($i = 1; $i <= 60; $i++) {
            $this->createPage("Mock Child $i", $parent->ID);
        }
        $output->writeln('Created Mock Filler with 40 children and Mock Parent with 60 children');
        return Command::SUCCESS;
    }

    private function createPage(string $title, int $parentID): SiteTree
    {
        $page = SiteTree::create();
        $page->Title = $title;
        $page->ParentID = $parentID;
        $page->write();
        $page->publishSingle();
        return $page;
    }
}
```
