### PR TITLE
FIX Guard entwine.warningLevel assignment against undefined entwine

### DIFF
--- a/client/src/legacy/LeftAndMain.Panel.js
+++ b/client/src/legacy/LeftAndMain.Panel.js
@@ -3,7 +3,12 @@ import $ from 'jquery';
 $.entwine('ss', function($) {
 
   // setup jquery.entwine
-  $.entwine.warningLevel = $.entwine.WARN_LEVEL_BESTPRACTISE;
+  // Guard against entwine being unavailable on the jQuery instance this module
+  // resolves during an AJAX panel load — assigning to an undefined entwine here
+  // throws and aborts panel init, freezing CMS menu navigation.
+  if ($.entwine) {
+    $.entwine.warningLevel = $.entwine.WARN_LEVEL_BESTPRACTISE;
+  }
 
   /**
    * Horizontal collapsible panel. Generic enough to work with CMS menu as well as various "filter" panels.

--- a/client/src/legacy/LeftAndMain.js
+++ b/client/src/legacy/LeftAndMain.js
@@ -70,7 +70,11 @@ $(window).on('resize.leftandmain', function(e) {
 });
 
 // setup jquery.entwine
-$.entwine.warningLevel = $.entwine.WARN_LEVEL_BESTPRACTISE;
+// Guard against entwine being unavailable on the resolved jQuery instance —
+// see LeftAndMain.Panel.js for the panel-load crash this prevents.
+if ($.entwine) {
+  $.entwine.warningLevel = $.entwine.WARN_LEVEL_BESTPRACTISE;
+}
 
 $.entwine('ss', function($) {
 


### PR DESCRIPTION
While clicking into a record in a ModelAdmin (an AJAX panel load), `LeftAndMain.Panel.js` runs:

```js
\$.entwine.warningLevel = \$.entwine.WARN_LEVEL_BESTPRACTISE;
```

In some load orderings the jQuery instance this module resolves does not (yet) have `entwine` attached, so `\$.entwine` is `undefined`. The assignment then throws:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'WARN_LEVEL_BESTPRACTISE')
```

The throw happens inside the panel bootstrap that is `globalEval`'d from the panel AJAX response, aborting panel initialisation. The practical symptom is that **CMS left-hand menu navigation stops responding** (menu carets / menu links dead) after opening a detail view.

### Fix

Null-check `\$.entwine` before assigning `warningLevel`. If entwine is not present on the resolved jQuery, skip the assignment rather than throwing and aborting init. Applied in both `LeftAndMain.Panel.js` and `LeftAndMain.js` (same pattern in both).

### Notes
- Purely defensive; no behaviour change when entwine is present.
- Reproduced on admin 3.2.x consuming projects with several third-party CMS modules.

### Issues
- (none filed yet)

### Pull request checklist
- [x] The target branch is correct
- [x] All commits are relevant to the purpose of the PR
- [x] The commit messages follow our commit message guidelines
- [ ] Documentation (if relevant)
- [ ] CI is green